### PR TITLE
add inventory

### DIFF
--- a/core/calculator.css
+++ b/core/calculator.css
@@ -420,8 +420,6 @@ a.internal_link {
 	clear: both;
 }
 
-
-
 #about_us, #inventory_import_export {
 	border: 2px solid #8B90A1;
 	padding: 10px;
@@ -439,6 +437,13 @@ a.internal_link {
 #inventory_import_export {
 	text-align: center;
 	box-sizing: border-box;
+}
+
+.inventory_import_export_toggle {
+	display: block;
+	margin-left: auto;
+	margin-right: 0;
+	margin-bottom: 10px;
 }
 
 .inventory_import_export_textarea {
@@ -464,6 +469,7 @@ a.internal_link {
 	background-color: #EEE;
 	background-clip: content-box;
 }
+
 body {
 	font-family: sans-serif;
 	margin-left: 0;
@@ -471,6 +477,7 @@ body {
 	padding-left: 0;
 	padding-right: 0;
 }
+
 .desired_item_count {
 	font-family: sans-serif;
 }

--- a/core/calculator.css
+++ b/core/calculator.css
@@ -422,10 +422,7 @@ a.internal_link {
 
 
 
-
-
-
-#about_us {
+#about_us, #inventory_import_export {
 	border: 2px solid #8B90A1;
 	padding: 10px;
 	border-radius: 5px;
@@ -439,8 +436,29 @@ a.internal_link {
 	display: none;
 }
 
+#inventory_import_export {
+	text-align: center;
+	box-sizing: border-box;
+}
 
+.inventory_import_export_textarea {
+	width: 100%;
+	display: block;
+	box-sizing: border-box;
+	min-height: 200px;
+	min-height: 20vh;
+}
 
+#inventory_amount_input_wrapper {
+	box-sizing: border-box;
+	text-align: center;
+}
+
+#inventory_amount_input {
+	text-align: center;
+	box-sizing: border-box;
+	width: calc(100% - 10px);
+}
 
 .menu_style {
 	background-color: #EEE;

--- a/core/calculator.css
+++ b/core/calculator.css
@@ -450,7 +450,6 @@ a.internal_link {
 	width: 100%;
 	display: block;
 	box-sizing: border-box;
-	min-height: 200px;
 	min-height: 20vh;
 }
 

--- a/core/calculator.css
+++ b/core/calculator.css
@@ -454,6 +454,16 @@ a.internal_link {
 	min-height: 20vh;
 }
 
+.inventory_import_error {
+	color: red;
+	font-weight: bold;
+	text-align: center;
+}
+
+.hidden {
+	display: none;
+}
+
 #inventory_amount_input_wrapper {
 	box-sizing: border-box;
 	text-align: center;

--- a/core/calculator.html
+++ b/core/calculator.html
@@ -53,7 +53,7 @@
 		<div id="content" class="content">
 			<div id="content_field" class="menu_style">
 				<div id="inventory_import_export">
-					<input type="button" class="inventory_import_export_toggle" title="X" value="X"/>
+					<input type="button" class="inventory_import_export_toggle" title="&#9587;" value="&#9587;"/>
 					<textarea id="inventory_import_text" class="inventory_import_export_textarea" placeholder="Inventory as JSON object" ></textarea>
 					<p id="inventory_import_error" class="inventory_import_error hidden">ERROR: The inventory is no valid JSON. The inventory has not been updated.</p>
 				</div>

--- a/core/calculator.html
+++ b/core/calculator.html
@@ -35,17 +35,10 @@
 			<a href="#" id="reset_item_count"><div class="home_button"> Reset Item Counts</div></a>
 			<a href="mailto:admin@resourcecalculator.com?Subject=Resource%20Calculator%20Issue"><div class="home_button">Report An Issue</div></a>
 			<a href="https://github.com/AsherGlick/ResourceCalculator/blob/master/README.md"><div class="home_button">Contribute</div></a>
-			<a><div id="inventory_import_export_button" class="home_button">Inventory</div></a>
 			<a><div id="about_button" class="home_button">About</div></a>
 			<!--<a><div id="share_button" class="home_button">Share</div></a>-->
 		</div>
 
-		<div id="inventory_import_export">
-			<textarea id="inventory_import_text" class="inventory_import_export_textarea" placeholder="Inventory as JSON object" ></textarea>
-			<br />
-			<input type="button" id="inventory_import_button" title="Load Inventory from JSON-Textbox" value="Load Inventory from JSON-Textbox"/>&nbsp;
-			<input type="button" id="inventory_export_button" title="Save Inventory to JSON-Textbox" value="Save Inventory to JSON-Textbox"/>
-		</div>
 		<div id="about_us">
 			Resource Calculator is an open source project to allow players to easily calculate how many raw resources they need in order to construct the items they want.
 			It was originally created by Asher Glick. You can help keep Resource Calculator up to date or add resources for new games by clicking on the Contribute button above. <br><br> The resources and recipes for the <b>{{resource_list}} calculator</b> were created and updated by<br>
@@ -59,6 +52,14 @@
 
 		<div id="content" class="content">
 			<div id="content_field" class="menu_style">
+				<div id="inventory_import_export">
+					<input type="button" class="inventory_import_export_toggle" title="X" value="X"/>
+					<textarea id="inventory_import_text" class="inventory_import_export_textarea" placeholder="Inventory as JSON object" ></textarea>
+					<br />
+					<input type="button" id="inventory_import_button" title="Load Inventory from JSON-Textbox" value="Load Inventory from JSON-Textbox"/>&nbsp;
+					<input type="button" id="inventory_export_button" title="Save Inventory to JSON-Textbox" value="Save Inventory to JSON-Textbox"/>
+				</div>
+				<input type="button" class="inventory_import_export_toggle" title="Show/Hide Inventory as Text" value="Show/Hide Inventory as Text"/>
 				<div class="search_bar">
 					<div class='hide_unused_wrapper'>
 						<input type="checkbox" id="unused_hide_checkbox" class="hide_unused_checkbox" />

--- a/core/calculator.html
+++ b/core/calculator.html
@@ -30,18 +30,29 @@
 		</style>
 	</head>
 	<body>
-
 		<div class="header_bar">
-			<a href="/" onClick="window.location.hash=''; window.location.reload()"><div class="home_button_logo">&nbsp;</div></a><a href="#" id="reset_item_count"><div class="home_button"> Reset Item Counts</div></a><a href="mailto:admin@resourcecalculator.com?Subject=Resource%20Calculator%20Issue"><div class="home_button">Report An Issue</div></a><a href="https://github.com/AsherGlick/ResourceCalculator/blob/master/README.md"><div class="home_button">Contribute</div></a><a><div id="about_button" class="home_button">About</div></a><!--<a><div id="share_button" class="home_button">Share</div></a>-->
+			<a href="/" onClick="window.location.hash=''; window.location.reload()"><div class="home_button_logo">&nbsp;</div></a>
+			<a href="#" id="reset_item_count"><div class="home_button"> Reset Item Counts</div></a>
+			<a href="mailto:admin@resourcecalculator.com?Subject=Resource%20Calculator%20Issue"><div class="home_button">Report An Issue</div></a>
+			<a href="https://github.com/AsherGlick/ResourceCalculator/blob/master/README.md"><div class="home_button">Contribute</div></a>
+			<a><div id="inventory_import_export_button" class="home_button">Inventory</div></a>
+			<a><div id="about_button" class="home_button">About</div></a>
+			<!--<a><div id="share_button" class="home_button">Share</div></a>-->
 		</div>
 
+		<div id="inventory_import_export">
+			<textarea id="inventory_import_text" class="inventory_import_export_textarea" placeholder="Inventory as JSON object" ></textarea>
+			<br />
+			<input type="button" id="inventory_import_button" title="Load Inventory from JSON-Textbox" value="Load Inventory from JSON-Textbox"/>&nbsp;
+			<input type="button" id="inventory_export_button" title="Save Inventory to JSON-Textbox" value="Save Inventory to JSON-Textbox"/>
+		</div>
 		<div id="about_us">
 			Resource Calculator is an open source project to allow players to easily calculate how many raw resources they need in order to construct the items they want.
 			It was originally created by Asher Glick. You can help keep Resource Calculator up to date or add resources for new games by clicking on the Contribute button above. <br><br> The resources and recipes for the <b>{{resource_list}} calculator</b> were created and updated by<br>
 			{% for author in authors %}
 
 
-				- <a {% if authors[author] != "" %}href="{{authors[author]}}"{% endif %}>{{ author }}</a><br>
+			- <a {% if authors[author] != "" %}href="{{authors[author]}}"{% endif %}>{{ author }}</a><br>
 			{% endfor %}
 		</div>
 
@@ -75,7 +86,7 @@
 			<!-- Instruction on how to use the site, maybe should be a popup modal on first visit -->
 			<div class="instructions">
 				<b>1)</b> Click on an item above. <b>2)</b> Enter in the amount that item you want. <b>3)</b> Click the <u>Calculate Resources</u> button below.<br>
-				Double click an item to change the recipe used to make that item. Then click <u>Calculate Resources</u> again.
+				Double click an item to change the recipe used to make that item or change the amount you already own of that item. Then click <u>Calculate Resources</u> again.
 			</div>
 
 			<!-- Advertisement -->
@@ -133,6 +144,12 @@
 				All Recipes
 			</div>
 			<div id="recipe_selector_list"></div>
+			<div class="recipe_selector_title">
+				Inventory Amount
+			</div>
+			<div id="inventory_amount_input_wrapper">
+				<input type="number" id="inventory_amount_input"/>
+			</div>
 		</div>
 
 

--- a/core/calculator.html
+++ b/core/calculator.html
@@ -55,9 +55,7 @@
 				<div id="inventory_import_export">
 					<input type="button" class="inventory_import_export_toggle" title="X" value="X"/>
 					<textarea id="inventory_import_text" class="inventory_import_export_textarea" placeholder="Inventory as JSON object" ></textarea>
-					<br />
-					<input type="button" id="inventory_import_button" title="Load Inventory from JSON-Textbox" value="Load Inventory from JSON-Textbox"/>&nbsp;
-					<input type="button" id="inventory_export_button" title="Save Inventory to JSON-Textbox" value="Save Inventory to JSON-Textbox"/>
+					<p id="inventory_import_error" class="inventory_import_error hidden">ERROR: The inventory is no valid JSON. The inventory has not been updated</p>
 				</div>
 				<input type="button" class="inventory_import_export_toggle" title="Show/Hide Inventory as Text" value="Show/Hide Inventory as Text"/>
 				<div class="search_bar">

--- a/core/calculator.html
+++ b/core/calculator.html
@@ -55,7 +55,7 @@
 				<div id="inventory_import_export">
 					<input type="button" class="inventory_import_export_toggle" title="X" value="X"/>
 					<textarea id="inventory_import_text" class="inventory_import_export_textarea" placeholder="Inventory as JSON object" ></textarea>
-					<p id="inventory_import_error" class="inventory_import_error hidden">ERROR: The inventory is no valid JSON. The inventory has not been updated</p>
+					<p id="inventory_import_error" class="inventory_import_error hidden">ERROR: The inventory is no valid JSON. The inventory has not been updated.</p>
 				</div>
 				<input type="button" class="inventory_import_export_toggle" title="Show/Hide Inventory as Text" value="Show/Hide Inventory as Text"/>
 				<div class="search_bar">

--- a/core/calculator.js
+++ b/core/calculator.js
@@ -33,7 +33,7 @@ $("#inventory_export_button").click(export_inventory_to_textbox);
 /******************************************************************************\
 | "About Us" Button Logic                                                      |
 \******************************************************************************/
-$("#inventory_import_export_button").click(function() {
+$(".inventory_import_export_toggle").click(function() {
 	$("#inventory_import_export").slideToggle();
 });
 

--- a/core/calculator.js
+++ b/core/calculator.js
@@ -242,6 +242,7 @@ function import_inventory_from_textbox(){
 	}
 	else {
 		inventory = {};
+		$("#inventory_import_error").addClass("hidden");
 	}
 
 	inventory = remove_null_entries(inventory);
@@ -296,22 +297,22 @@ function generatelist() {
 		// For each negative requirement get it's base resources
 		for (let requirement in requirements){
 			if (requirements[requirement] < 0) {
-				var recipe = get_recipe(requirement);
-				var recipe_requirements = recipe.requirements;
-				var recipe_output = recipe.output;
+				let recipe = get_recipe(requirement);
+				let recipe_requirements = recipe.requirements;
+				let recipe_output = recipe.output;
 
 				if (remaining_inventory_items[requirement] > 0) {
-					var owned = remaining_inventory_items[requirement];
-					var needed = Math.abs(requirements[requirement]);
-					var recipes_from_owned = Math.floor(owned / recipe_output);
-					var overshot_from_owned = owned % recipe_output;
-					var extra_from_produce = needed % recipe_output;
+					let owned = remaining_inventory_items[requirement];
+					let needed = Math.abs(requirements[requirement]);
+					let recipes_from_owned = Math.floor(owned / recipe_output);
+					let overshot_from_owned = owned % recipe_output;
+					let extra_from_produce = needed % recipe_output;
 
 					if (overshot_from_owned < extra_from_produce){
 						recipes_from_owned--;
 					}
 
-					var usable_count =  Math.min(needed, extra_from_produce + recipes_from_owned*recipe_output);
+					let usable_count =  Math.min(needed, extra_from_produce + recipes_from_owned * recipe_output);
 
 					remaining_inventory_items[requirement] -= usable_count;
 					output_requirements[requirement] += usable_count;
@@ -323,12 +324,12 @@ function generatelist() {
 
 					used_from_inventory[requirement] += usable_count;
 
-					let tracker_key = requirement+requirement + inventory_label_suffix;
+					let tracker_key = requirement + requirement + inventory_label_suffix;
 					if (!(tracker_key in resource_tracker)) {
 						resource_tracker[tracker_key] = {
-							"source":requirement + inventory_label_suffix,
-							"target":requirement,
-							"value":0,
+							"source": requirement + inventory_label_suffix,
+							"target": requirement,
+							"value": 0,
 						};
 					}
 
@@ -344,12 +345,12 @@ function generatelist() {
 					// console.log("using " + usable_count + " " + requirement + " from inventory.");
 				}
 
-				var required_count = -requirements[requirement];
+				let required_count = -requirements[requirement];
 				// Figure out the minimum number of a given requirement can be produced
 				// to fit the quantity of that requirement needed.
 				// EG: if a recipe produces 4 of an item but you only need 3
 				//     then you must produce 4 of that item with 1 left over
-				var produce_count = Math.ceil(required_count/recipe_output);
+				let produce_count = Math.ceil(required_count / recipe_output);
 				output_requirements[requirement] += produce_count * recipe_output;
 
 				// Add the quantity of the item created to the generation_totals
@@ -357,6 +358,7 @@ function generatelist() {
 				if (!(requirement in generation_totals)) {
 					generation_totals[requirement] = 0;
 				}
+
 				generation_totals[requirement] += produce_count * recipe_output;
 
 				// if this is a raw resource then add it to the raw resource list
@@ -364,6 +366,7 @@ function generatelist() {
 					if (raw_resources[requirement] === undefined) {
 						raw_resources[requirement] = 0;
 					}
+
 					raw_resources[requirement] += produce_count * recipe_output;
 				}
 
@@ -432,10 +435,10 @@ function generatelist() {
 		var source = resource_tracker_copy[tracked_resource].source;
 		if (source in original_requirements) {
 
-			var final_tracker = source+"final";
+			var final_tracker = source + "final";
 			resource_tracker[final_tracker] = {
 				"source": source,
-				"target":"[Final] " + source,
+				"target": "[Final] " + source,
 				"value": -original_requirements[source],
 			};
 
@@ -568,10 +571,9 @@ function build_instruction_line(edges, item_name, generation_totals) {
 }
 
 function build_instruction_inventory_line(edges, item_name) {
-	// Build the input item sub string
-	var amount_to_take = 0;
+	let amount_to_take = 0;
 	for (let edge in edges){
-		// If this is pointing into the resource we are currently trying to craft
+		// If this is pointing into the resource we are currently trying to take from the inventory.
 		if (edges[edge].target === item_name && (edges[edge].source.endsWith(inventory_label_suffix))) {
 			amount_to_take = edges[edge].value;
 			break;
@@ -583,7 +585,6 @@ function build_instruction_inventory_line(edges, item_name) {
 	}
 
 	let line_wrapper = $("<div/>").addClass("instruction_wrapper");
-	// Raw Text
 	$("<span/>").text("Take ").appendTo(line_wrapper);
 
 	text_item_object(amount_to_take, item_name).appendTo(line_wrapper);
@@ -833,15 +834,12 @@ function generate_chart(edges, node_quantities, used_from_inventory) {
 	var nodes = {};
 	for (let column_id in columns) {
 		for (let node_id in columns[column_id]) {
-			var node_name = columns[column_id][node_id];
+			let node_name = columns[column_id][node_id];
 
 			let input = get_input_size(edges, node_name);
 			let output;
-			let size;
 			if (node_name.endsWith(inventory_label_suffix)) {
-				let inventory_item_count = used_from_inventory[node_name.replace(inventory_label_suffix, "")];
-				output = inventory_item_count;
-				size = inventory_item_count;
+				output = used_from_inventory[node_name.replace(inventory_label_suffix, "")];
 			}
 			else {
 				output = node_quantities[node_name];
@@ -851,7 +849,7 @@ function generate_chart(edges, node_quantities, used_from_inventory) {
 				output += used_from_inventory[node_name];
 			}
 
-			size = Math.max(output, input);
+			let size = Math.max(output, input);
 
 			// console.log(node);
 			nodes[node_name] = {
@@ -1553,10 +1551,9 @@ function switch_recipe(item_name, event) {
 }
 
 function switch_inventory_amount_input(item_name) {
-	let item_amount_in_inventory = inventory[item_name];
 	let inventory_amount_input = $("#inventory_amount_input");
 	inventory_amount_input.data("item_name", item_name);
-	inventory_amount_input.val(item_amount_in_inventory);
+	inventory_amount_input.val(inventory[item_name]);
 }
 
 $("#recipe_select").mouseleave(function() {
@@ -1566,9 +1563,7 @@ $("#recipe_select").mouseleave(function() {
 
 $("#inventory_amount_input").change(function(){
 	let inventory_amount_input = $("#inventory_amount_input");
-	let value = inventory_amount_input.val();
-	let item_name = inventory_amount_input.data("item_name");
-	inventory[item_name] = value - 0; // easy string-to-int conversion
+	inventory[inventory_amount_input.data("item_name")] = inventory_amount_input.val() - 0; // easy string-to-int conversion
 	export_inventory_to_localstorage();
 	export_inventory_to_textbox();
 });

--- a/core/calculator.js
+++ b/core/calculator.js
@@ -312,6 +312,7 @@ function generatelist() {
 						recipes_from_owned--;
 					}
 
+					// Only take so much from inventory, that no [Extra] will be crafted.
 					let usable_count =  Math.min(needed, extra_from_produce + recipes_from_owned * recipe_output);
 
 					remaining_inventory_items[requirement] -= usable_count;

--- a/core/calculator.js
+++ b/core/calculator.js
@@ -447,6 +447,12 @@ function generatelist() {
 		}
 	}
 
+	for (let tracked_resource in resource_tracker) {
+		if (resource_tracker[tracked_resource].value === 0) {
+			delete resource_tracker[tracked_resource];
+		}
+	}
+
 	generate_chart(resource_tracker, generation_totals, used_from_inventory);
 	generate_instructions(resource_tracker, generation_totals);
 }
@@ -841,8 +847,11 @@ function generate_chart(edges, node_quantities, used_from_inventory) {
 			if (node_name.endsWith(inventory_label_suffix)) {
 				output = used_from_inventory[node_name.replace(inventory_label_suffix, "")];
 			}
-			else {
+			else if (node_quantities[node_name] !== undefined) {
 				output = node_quantities[node_name];
+			}
+			else {
+				output = 0;
 			}
 
 			if (used_from_inventory[node_name] !== undefined) {

--- a/core/calculator.js
+++ b/core/calculator.js
@@ -27,8 +27,7 @@ function clear_item_counts() {
 	generatelist();
 }
 $("#reset_item_count").click(clear_item_counts);
-$("#inventory_import_button").click(import_inventory_from_textbox);
-$("#inventory_export_button").click(export_inventory_to_textbox);
+$("#inventory_import_text").change(import_inventory_from_textbox);
 
 /******************************************************************************\
 | "About Us" Button Logic                                                      |
@@ -226,11 +225,25 @@ function import_inventory_from_localstorage() {
 	let inventoryContent = JSON.parse(localStorage.getItem("[" + calculatorName + " Inventory]"));
 	inventory = inventoryContent ? inventoryContent : {};
 	inventory = remove_null_entries(inventory);
+	export_inventory_to_textbox();
 	return inventory;
 }
 
 function import_inventory_from_textbox(){
-	inventory = JSON.parse($("#inventory_import_text").val());
+	var text = $("#inventory_import_text").val();
+	if (text.trim().length > 0){
+		try {
+			inventory = JSON.parse(text);
+			$("#inventory_import_error").addClass("hidden");
+		}
+		catch (exception) {
+			$("#inventory_import_error").removeClass("hidden");
+		}
+	}
+	else {
+		inventory = {};
+	}
+
 	inventory = remove_null_entries(inventory);
 	export_inventory_to_localstorage();
 }

--- a/core/calculator.js
+++ b/core/calculator.js
@@ -574,6 +574,10 @@ function build_instruction_line(edges, item_name, generation_totals) {
 
 	var recipe_type = get_recipe(item_name).recipe_type;
 
+	if (recipe_type_functions[recipe_type] === undefined) {
+		return $("<div/>");
+	}
+
 	return recipe_type_functions[recipe_type](inputs, item_name, generation_totals[item_name], text_item_object);
 }
 

--- a/core/calculator.js
+++ b/core/calculator.js
@@ -27,11 +27,16 @@ function clear_item_counts() {
 	generatelist();
 }
 $("#reset_item_count").click(clear_item_counts);
-
+$("#inventory_import_button").click(import_inventory_from_textbox);
+$("#inventory_export_button").click(export_inventory_to_textbox);
 
 /******************************************************************************\
 | "About Us" Button Logic                                                      |
 \******************************************************************************/
+$("#inventory_import_export_button").click(function() {
+	$("#inventory_import_export").slideToggle();
+});
+
 $("#about_button").click(function() {
 	$("#about_us").slideToggle();
 });
@@ -67,6 +72,7 @@ $(".desired_item").each(function() {
 	// When doubleclicking open the recipe select menu
 	item.dblclick( function (event) {
 		switch_recipe(item.attr("mc_value"), event);
+		switch_inventory_amount_input(item.attr("mc_value"));
 	});
 
 	// Enable item name hover text
@@ -164,6 +170,26 @@ function save() {
 		window.location.hash = $.param(selected_items);
 	}
 
+	export_inventory_to_localstorage();
+}
+
+var inventory = {};
+var inventory_label_suffix = " [from Inventory]";
+function export_inventory_to_localstorage(input) {
+	if (!input) {
+		input = inventory;
+	}
+
+	input = remove_null_entries(input);
+
+	input = input ? input : {};
+	let calculatorName = window.location.pathname.replaceAll("/", "");
+	localStorage.setItem("[" + calculatorName + " Inventory]", JSON.stringify(input));
+}
+
+function export_inventory_to_textbox() {
+	inventory = remove_null_entries(inventory);
+	$("#inventory_import_text").val(JSON.stringify(inventory ? inventory : {}, null, 1));
 }
 
 
@@ -171,11 +197,14 @@ function save() {
 | load()                                                                       |
 |                                                                              |
 | This function is an inverse to save() and reads the state of the resource    |
-| requirement list from the UIR hash. In addition it will automatically call   |
+| requirement list from the URI hash. In addition it will automatically call   |
 | generatelist() to save the user from having to click the button for a saved  |
 | list.                                                                        |
 \******************************************************************************/
 function load() {
+	import_inventory_from_localstorage();
+	export_inventory_to_textbox();
+
 	var uri_arguments = decodeURIComponent(window.location.hash.substr(1));
 	if (uri_arguments !== "") {
 		var pairs = uri_arguments.split("&");
@@ -192,6 +221,29 @@ function load() {
 	$("#unused_hide_checkbox").change();
 }
 
+function import_inventory_from_localstorage() {
+	let calculatorName = window.location.pathname.replaceAll("/", "");
+	let inventoryContent = JSON.parse(localStorage.getItem("[" + calculatorName + " Inventory]"));
+	inventory = inventoryContent ? inventoryContent : {};
+	inventory = remove_null_entries(inventory);
+	return inventory;
+}
+
+function import_inventory_from_textbox(){
+	inventory = JSON.parse($("#inventory_import_text").val());
+	inventory = remove_null_entries(inventory);
+	export_inventory_to_localstorage();
+}
+
+function remove_null_entries(item_collection) {
+	for (var item_name in item_collection) {
+		if (!item_collection[item_name]){
+			delete item_collection[item_name];
+		}
+	}
+
+	return item_collection;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 ///////////////////////// Requirements Calculation Logic ///////////////////////
@@ -216,6 +268,9 @@ function generatelist() {
 	var resource_tracker = {};
 	var generation_totals = {}; // the total number of each resource produce (ignoring any consumption)
 
+	var remaining_inventory_items = JSON.parse(JSON.stringify(inventory));
+	var used_from_inventory = {};
+
 	var raw_resources = {};
 
 	// While we still have something that requires another resource to create
@@ -228,45 +283,88 @@ function generatelist() {
 		// For each negative requirement get it's base resources
 		for (let requirement in requirements){
 			if (requirements[requirement] < 0) {
+				var recipe = get_recipe(requirement);
+				var recipe_requirements = recipe.requirements;
+				var recipe_output = recipe.output;
 
+				if (remaining_inventory_items[requirement] > 0) {
+					var owned = remaining_inventory_items[requirement];
+					var needed = Math.abs(requirements[requirement]);
+					var recipes_from_owned = Math.floor(owned / recipe_output);
+					var overshot_from_owned = owned % recipe_output;
+					var extra_from_produce = needed % recipe_output;
 
-				var recipe = get_recipe(requirement).requirements;
-				var produces_count = get_recipe(requirement).output;
+					if (overshot_from_owned < extra_from_produce){
+						recipes_from_owned--;
+					}
+
+					var usable_count =  Math.min(needed, extra_from_produce + recipes_from_owned*recipe_output);
+
+					remaining_inventory_items[requirement] -= usable_count;
+					output_requirements[requirement] += usable_count;
+					requirements[requirement] += usable_count;
+
+					if (used_from_inventory[requirement] === undefined) {
+						used_from_inventory[requirement] = 0;
+					}
+
+					used_from_inventory[requirement] += usable_count;
+
+					let tracker_key = requirement+requirement + inventory_label_suffix;
+					if (!(tracker_key in resource_tracker)) {
+						resource_tracker[tracker_key] = {
+							"source":requirement + inventory_label_suffix,
+							"target":requirement,
+							"value":0,
+						};
+					}
+
+					resource_tracker[tracker_key].value += usable_count;
+
+					let inventory_key = requirement + inventory_label_suffix;
+					if (!(inventory_key in generation_totals)) {
+						generation_totals[inventory_key] = 0;
+					}
+
+					generation_totals[inventory_key] += usable_count;
+
+					// console.log("using " + usable_count + " " + requirement + " from inventory.");
+				}
+
 				var required_count = -requirements[requirement];
-
 				// Figure out the minimum number of a given requirement can be produced
 				// to fit the quantity of that requirement needed.
 				// EG: if a recipe produces 4 of an item but you only need 3
 				//     then you must produce 4 of that item with 1 left over
-				var produce_count = Math.ceil(required_count/produces_count);
-				output_requirements[requirement] += produce_count * produces_count;
+				var produce_count = Math.ceil(required_count/recipe_output);
+				output_requirements[requirement] += produce_count * recipe_output;
 
 				// Add the quantity of the item created to the generation_totals
 				// This is used to keep track of how many of any item in the crafting process are produced
 				if (!(requirement in generation_totals)) {
 					generation_totals[requirement] = 0;
 				}
-				generation_totals[requirement] += produce_count * produces_count;
+				generation_totals[requirement] += produce_count * recipe_output;
 
 				// if this is a raw resource then add it to the raw resource list
-				if (recipe[requirement] === 0 && Object.keys(recipe).length === 1) {
+				if (recipe_requirements[requirement] === 0 && Object.keys(recipe_requirements).length === 1) {
 					if (raw_resources[requirement] === undefined) {
 						raw_resources[requirement] = 0;
 					}
-					raw_resources[requirement] += produce_count * produces_count;
+					raw_resources[requirement] += produce_count * recipe_output;
 				}
 
-				// If this is not a raw resource, track the change the  and modify the output requirements
+				// If this is not a raw resource, track the change the and modify the output requirements
 				else {
-					$.each(recipe, function(item) {
+					$.each(recipe_requirements, function(item) {
 						// Set the recipe requirements as new output requirements
 						if (output_requirements[item] === undefined) {
 							output_requirements[item] = 0;
 						}
-						output_requirements[item] += recipe[item] * produce_count;
+						output_requirements[item] += recipe_requirements[item] * produce_count;
 
 						// Add the recipe's conversion
-						var tracker_key = requirement+item;
+						let tracker_key = requirement+item;
 						if (!(tracker_key in resource_tracker)) {
 							resource_tracker[tracker_key] = {
 								"source":item,
@@ -274,13 +372,15 @@ function generatelist() {
 								"value":0,
 							};
 						}
-						resource_tracker[tracker_key].value += recipe[item] * -produce_count;
+						resource_tracker[tracker_key].value += recipe_requirements[item] * -produce_count;
 					});
 				}
 			}
 		}
 		requirements = output_requirements;
 	}
+
+	// console.log("Used from inventory:", used_from_inventory);
 
 	for (let original_requirement in original_requirements) {
 		// console.log(get_recipe(original_requirement));
@@ -292,7 +392,6 @@ function generatelist() {
 			};
 		}
 	}
-
 
 	// This maps all extra items to an extra value
 	// It is done in order to get the right heights for items that produce more then they take
@@ -320,8 +419,8 @@ function generatelist() {
 		var source = resource_tracker_copy[tracked_resource].source;
 		if (source in original_requirements) {
 
-			var final_trakcer = source+"final";
-			resource_tracker[final_trakcer] = {
+			var final_tracker = source+"final";
+			resource_tracker[final_tracker] = {
 				"source": source,
 				"target":"[Final] " + source,
 				"value": -original_requirements[source],
@@ -332,12 +431,9 @@ function generatelist() {
 		}
 	}
 
-
-
-	generate_chart(resource_tracker, generation_totals);
+	generate_chart(resource_tracker, generation_totals, used_from_inventory);
 	generate_instructions(resource_tracker, generation_totals);
 }
-
 
 /******************************************************************************\
 |
@@ -366,23 +462,41 @@ function generate_instructions(edges, generation_totals) {
 	var instructions = $("<div/>");
 	var column_count = 0;
 
-	$("<div/>").attr("id", "text_instructions_title").text("Base Ingredients").appendTo(instructions);
+	var inventory_resources = [];
+	var needed_resources = [];
 	// List out raw resource numbers
 	for (let node in node_columns){
 		if (node_columns[node] === 0) {
-
-
 			var line_wrapper = $("<div/>");
 			line_wrapper.addClass("instruction_wrapper");
-			var base_ingredients = text_item_object(generation_totals[node], node);
+			let is_inventory = node.endsWith(inventory_label_suffix);
+			var base_ingredients = text_item_object(generation_totals[node], node.replace(inventory_label_suffix, ""));
 			base_ingredients.appendTo(line_wrapper);
-			line_wrapper.appendTo(instructions);
 
+			if (is_inventory) {
+				inventory_resources.push(line_wrapper);
+			}
+			else {
+				needed_resources.push(line_wrapper);
+			}
 		}
 
 		// Track the largest column as the max column count
 		if (node_columns[node] >= column_count) {
 			column_count = node_columns[node]+1;
+		}
+	}
+
+
+	$("<div/>").attr("id", "text_instructions_title").text((inventory_resources.length > 0 ? "Missing " : "") + "Base Ingredients").appendTo(instructions);
+	for (let needed_resource in needed_resources) {
+		needed_resources[needed_resource].appendTo(instructions);
+	}
+
+	if (inventory_resources.length > 0) {
+		$("<div/>").attr("id", "text_instructions_title").text("Already Owned Base Ingredients").appendTo(instructions);
+		for (let inventory_resource in inventory_resources) {
+			inventory_resources[inventory_resource].appendTo(instructions);
 		}
 	}
 
@@ -398,8 +512,13 @@ function generate_instructions(edges, generation_totals) {
 				}
 
 				build_instruction_line(edges, node, generation_totals).appendTo(instructions);
+				let instruction_inventory_line = build_instruction_inventory_line(edges, node);
+				if (instruction_inventory_line) {
+					instruction_inventory_line.appendTo(instructions);
+				}
 			}
 		}
+
 		var line_break = $("<div/>");
 		line_break.addClass("instruction_line_break");
 		line_break.appendTo(instructions);
@@ -417,11 +536,15 @@ function generate_instructions(edges, generation_totals) {
 }
 
 function build_instruction_line(edges, item_name, generation_totals) {
+	if (!generation_totals[item_name]) {
+		return $("<div/>");
+	}
+
 	// Build the input item sub string
 	var inputs = {};
 	for (let edge in edges){
 		// If this is pointing into the resource we are currently trying to craft
-		if (edges[edge].target === item_name) {
+		if (edges[edge].target === item_name && !(edges[edge].source.endsWith(inventory_label_suffix))) {
 			inputs[edges[edge].source] = edges[edge].value;
 		}
 	}
@@ -431,6 +554,29 @@ function build_instruction_line(edges, item_name, generation_totals) {
 	return recipe_type_functions[recipe_type](inputs, item_name, generation_totals[item_name], text_item_object);
 }
 
+function build_instruction_inventory_line(edges, item_name) {
+	// Build the input item sub string
+	var amount_to_take = 0;
+	for (let edge in edges){
+		// If this is pointing into the resource we are currently trying to craft
+		if (edges[edge].target === item_name && (edges[edge].source.endsWith(inventory_label_suffix))) {
+			amount_to_take = edges[edge].value;
+			break;
+		}
+	}
+
+	if (!amount_to_take) {
+		return null;
+	}
+
+	let line_wrapper = $("<div/>").addClass("instruction_wrapper");
+	// Raw Text
+	$("<span/>").text("Take ").appendTo(line_wrapper);
+
+	text_item_object(amount_to_take, item_name).appendTo(line_wrapper);
+	$("<span/>").text(" from inventory.").appendTo(line_wrapper);
+	return line_wrapper;
+}
 
 function build_unit_value_list(number, unit_name, item_name) {
 	if (number === 0) {
@@ -489,6 +635,10 @@ function get_unit_size(unit_name, item_name) {
 
 function text_item_object(count, name){
 	var item_object = $("<div/>");
+	if (!count) {
+		return item_object;
+	}
+
 	item_object.addClass("instruction_item");
 
 
@@ -644,7 +794,7 @@ function get_columns(edges) {
 | Arguments
 |   generation_events -
 \******************************************************************************/
-function generate_chart(edges, node_quantities) {
+function generate_chart(edges, node_quantities, used_from_inventory) {
 
 	// Set the margins for the area that the nodes and edges can take up
 	var margin = {
@@ -671,11 +821,30 @@ function generate_chart(edges, node_quantities) {
 	for (let column_id in columns) {
 		for (let node_id in columns[column_id]) {
 			var node_name = columns[column_id][node_id];
+
+			let input = get_input_size(edges, node_name);
+			let output;
+			let size;
+			if (node_name.endsWith(inventory_label_suffix)) {
+				let inventory_item_count = used_from_inventory[node_name.replace(inventory_label_suffix, "")];
+				output = inventory_item_count;
+				size = inventory_item_count;
+			}
+			else {
+				output = node_quantities[node_name];
+			}
+
+			if (used_from_inventory[node_name] !== undefined) {
+				output += used_from_inventory[node_name];
+			}
+
+			size = Math.max(output, input);
+
 			// console.log(node);
 			nodes[node_name] = {
-				"input": get_input_size(edges, node_name),
-				"output": node_quantities[node_name],
-				"size": Math.max(node_quantities[node_name], get_input_size(edges, node_name)),
+				"input": input,
+				"output": output,
+				"size": size,
 				"column": Number(column_id),
 				"passthrough": false,
 				"incoming_edges":[],
@@ -795,7 +964,7 @@ function relax_columns_left_to_right(alpha, columns, nodes, edges) {
 		return sum;
 	}
 	function raw_source_sum(node) {
-		// If the node is not a passthroguh then return the sum of all of
+		// If the node is not a passthrough then return the sum of all of
 		// the source edges
 		if (node.passthrough === false) {
 			var sum = 0;
@@ -849,7 +1018,7 @@ function relax_columns_right_to_left(alpha, columns, nodes, edges) {
 		return sum;
 	}
 	function raw_target_sum(node) {
-		// If the node is not a passthroguh then return the sum of all of
+		// If the node is not a passthrough then return the sum of all of
 		// the source edges
 		if (node.passthrough === false) {
 			var sum = 0;
@@ -1203,7 +1372,7 @@ function get_input_size(edges, output){
 ////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Hover Text Logic ///////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-// How far away from the mouse should hte hoverbox be
+// How far away from the mouse should the hoverbox be
 var hover_x_offset = 10;
 var hover_y_offset = -10;
 $(document).on("mousemove", function(e){
@@ -1370,12 +1539,26 @@ function switch_recipe(item_name, event) {
 	});
 }
 
+function switch_inventory_amount_input(item_name) {
+	let item_amount_in_inventory = inventory[item_name];
+	let inventory_amount_input = $("#inventory_amount_input");
+	inventory_amount_input.data("item_name", item_name);
+	inventory_amount_input.val(item_amount_in_inventory);
+}
 
 $("#recipe_select").mouseleave(function() {
 	$("#recipe_select").css("opacity", 0);
 	$("#recipe_select").css("pointer-events", "none");
 });
 
+$("#inventory_amount_input").change(function(){
+	let inventory_amount_input = $("#inventory_amount_input");
+	let value = inventory_amount_input.val();
+	let item_name = inventory_amount_input.data("item_name");
+	inventory[item_name] = value - 0; // easy string-to-int conversion
+	export_inventory_to_localstorage();
+	export_inventory_to_textbox();
+});
 
 ////////////////////////////////////////////////////////////////////////
 /////////////////////// Selection and modification of raw resources/////

--- a/core/calculator.js
+++ b/core/calculator.js
@@ -854,10 +854,7 @@ function generate_chart(edges, node_quantities, used_from_inventory) {
 
 			let input = get_input_size(edges, node_name);
 			let output;
-			if (node_name.endsWith(inventory_label_suffix)) {
-				output = used_from_inventory[node_name.replace(inventory_label_suffix, "")];
-			}
-			else if (node_quantities[node_name] !== undefined) {
+			if (node_quantities[node_name] !== undefined) {
 				output = node_quantities[node_name];
 			}
 			else {

--- a/core/calculator.js
+++ b/core/calculator.js
@@ -308,8 +308,13 @@ function generatelist() {
 					let overshot_from_owned = owned % recipe_output;
 					let extra_from_produce = needed % recipe_output;
 
-					if (overshot_from_owned < extra_from_produce){
-						recipes_from_owned--;
+					if (overshot_from_owned < extra_from_produce) {
+						if (recipes_from_owned > 0) {
+							recipes_from_owned--;
+						}
+						else {
+							extra_from_produce = 0;
+						}
 					}
 
 					// Only take so much from inventory, that no [Extra] will be crafted.

--- a/resource_lists/minecraft/resources.yaml
+++ b/resource_lists/minecraft/resources.yaml
@@ -2,6 +2,7 @@
 authors:
   Asher: "https://aglick.com"
   Kevin: "kroden3d@gmail.com"
+  Marc: "https://github.com/mmodrow"
 
 index_page_display_name: "Minecraft"
 # row_group_count: 0


### PR DESCRIPTION
I added the functionality to keep track of already owned items by using an inventory of owned items.

This is stored in local storage and a textarea as JSON for local persistence and the option to import/export the inventory to other machines or browsers. The Textarea resides in a pane, that is hidden by default and can be shown via the "Inventory"-Button in the top menu.
Besides manipulating the localstorage or the textarea content as JSON, you can also use the double-click-menu on the item, where I added a number box to keep track of the selected item's inventory stock. The double-click-menu input updates the textarea, the in-memory-inventory and the localstorage inventory on change, so it's effectively 0-click interaction.

Items in the inventory will be used instead of "required" items wherever reasonable. E.g. if you have 3 planks and need 6 only 2 will be used, as they can only be crafted in sets of 4. Using all 3 would cause 1 [Extra] to pop up in the graph.
In the text instructions inventory usage will be denoted as "Take [amount] [item] from inventory." and in the base ingredients, owned and needed items will be listed separately, if any inventory items can be used.

If no inventory items are stored, nothing changes besides the Inventory-button in the top menu and the inventory amount headline+number input in the double click menu.

New UI:
![image](https://user-images.githubusercontent.com/11810519/117372197-70db1e80-aec9-11eb-8144-9059347db9ef.png)

UI with no new features in use:
![image](https://user-images.githubusercontent.com/11810519/117372298-9a944580-aec9-11eb-97c2-a4b39590145c.png)

This fixes #22 

I also added myself as author for minecraft for my contribution in https://github.com/AsherGlick/ResourceCalculator/issues/16 .
I also took the liberty, to fix some more typos, spelling mistakes and remove some random empty lines as well as make some optimizations, where I touched the code.
