### PR TITLE
Replacing the internal YAML datum with a typed datastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 venv/
 output/
+/.coverage
 
 node_modules/
 package-lock.json

--- a/build.py
+++ b/build.py
@@ -328,14 +328,24 @@ def generate_content_width_css(image_width: int, resource_list: ResourceList) ->
     while iteration * row_group_count * image_width_with_padding < 3840:
         content_width = iteration * row_group_count * image_width_with_padding
         screen_max = (iteration + 1) * row_group_count * image_width_with_padding
-        new_css = "@media only screen and (max-width: " + str(screen_max + media_padding - 1) + "px) and (min-width:" + str(content_width + media_padding) + "px) { .resource_content { width: " + str(content_width) + "px}  }"
+        new_css = "@media only screen and (max-width: {}px) and (min-width:{}px) {{ .resource_content {{ width: {}px}}  }}".format(
+            str(screen_max + media_padding - 1),
+            str(content_width + media_padding),
+            str(content_width),
+        )
+
         content_width_css += new_css
         iteration += 1
     # When the width is less then a single group we still want the list to be centered
     for i in range(1, row_group_count):
         content_width = i * image_width_with_padding
         screen_max = (i + 1) * image_width_with_padding
-        new_css = "@media only screen and (max-width: " + str(screen_max + media_padding - 1) + "px) and (min-width:" + str(content_width + media_padding) + "px) { .resource_content { width: " + str(content_width) + "px}  }"
+        new_css = "@media only screen and (max-width: {}px) and (min-width:{}px) {{ .resource_content {{ width: {}px}}  }}".format(
+            str(screen_max + media_padding - 1),
+            str(content_width + media_padding),
+            str(content_width),
+        )
+
         content_width_css += new_css
 
     return content_width_css

--- a/build.py
+++ b/build.py
@@ -8,11 +8,10 @@ import re
 import shutil
 import subprocess
 import time
-import yaml
 from typing import OrderedDict
 from jinja2 import Environment, FileSystemLoader
 from PIL import Image  # type: ignore
-from typing import Any, Dict, TextIO, Tuple, Type, List, Set
+from typing import Dict, Tuple, List, Set
 
 from pylib.json_data_compressor import mini_js_data
 from pylib.uglifyjs import uglify_copyfile, uglify_js_string
@@ -147,7 +146,6 @@ def lint_javascript() -> None:
 # a recipe are present and that no additional unknown elements are present.
 ################################################################################
 def lint_recipes(calculator_name: str, item_name: str, recipes: List[Recipe]) -> List[TokenError]:
-# def lint_recipes(calculator_name: str, item_name: str, item_token: Token, recipes: List[Recipe]) -> None:
     errors: List[TokenError] = []
 
     # Check that every resource has a raw recipe
@@ -169,6 +167,7 @@ def lint_recipes(calculator_name: str, item_name: str, recipes: List[Recipe]) ->
         errors.append(TokenError(item_name + " must have only one \"Raw Resource\"", Token()))
 
     return errors
+
 
 ################################################################################
 #
@@ -260,6 +259,7 @@ def ensure_unique_simple_names(calculator_name: str, resources: OrderedDict[str,
 
     return errors
 
+
 ################################################################################
 #
 ################################################################################
@@ -320,7 +320,7 @@ def get_newest_modified_time(path: str) -> float:
 def generate_content_width_css(image_width: int, resource_list: ResourceList) -> str:
     content_width_css = ""
     media_padding = 40  # This give a slight padding from the edges, useful for avoiding intersection with scroll bars
-    
+
     row_group_count = resource_list.row_group_count
 
     iteration = 1
@@ -413,6 +413,7 @@ def merge_custom_multipliers(stack_sizes: OrderedDict[str, StackSize], resources
 
     return stack_sizes
 
+
 ################################################################################
 # expand_raw_resource allow for the syntactic candy of only defining a a
 # `recipe_type` value for raw resources and not having to define the entire
@@ -437,7 +438,6 @@ def expand_raw_resource(resources: OrderedDict[str, Resource]) -> OrderedDict[st
 def fill_default_requirement_groups(resources: OrderedDict[str, Resource], requirement_groups: OrderedDict[str, List[str]]) -> OrderedDict[str, Resource]:
     for resource in resources:
         for i, recipe in enumerate(resources[resource].recipes):
-            
             # Create a copy of the keys so we can iterate over them and mutate them
             requirement_list: List[str] = [requirement for requirement in recipe.requirements]
 
@@ -448,6 +448,7 @@ def fill_default_requirement_groups(resources: OrderedDict[str, Resource], requi
                     del recipe.requirements[requirement]
                     recipe.requirements[requirement_groups[requirement][0]] = value
     return resources
+
 
 def touch_output_folder_files(calculator_folder: str, timestamp: int = 0) -> None:
     if timestamp == 0:
@@ -513,25 +514,15 @@ def create_calculator_page(
         for error in errors:
             error.print_error(fulltext_lines)
 
-
     resources: OrderedDict[str, Resource] = resource_list.resources
-
     resources = expand_raw_resource(resources)
-
     resources = fill_default_requirement_groups(resources, resource_list.requirement_groups)
 
     authors: OrderedDict[str, str] = resource_list.authors
 
     recipe_types: OrderedDict[str, str] = resource_list.recipe_types
 
-
-
     stack_sizes: OrderedDict[str, StackSize] = resource_list.stack_sizes
-
-    #  = None
-    # if "stack_sizes" in yaml_data:
-    #     stack_sizes = yaml_data["stack_sizes"]
-    # run some sanity checks on the resources
 
     errors += lint_resources(calculator_name, resources, recipe_types, stack_sizes)
 
@@ -543,7 +534,6 @@ def create_calculator_page(
     if not FLAG_skip_uglify_js:
         recipe_type_format_js = uglify_js_string(recipe_type_format_js)
 
-    
     recipe_js = mini_js_data(get_primitive(get_recipes_only(resources)))
 
     html_resource_data = generate_resource_html_data(resources)

--- a/build.py
+++ b/build.py
@@ -506,14 +506,6 @@ def create_calculator_page(
         resource_list = ResourceList()
         errors += resource_list.parse(yaml_data)
 
-    if len(errors) > 0:
-        with open(resource_list_file, 'r', encoding="utf_8") as f:
-            fulltext = f.read()
-            fulltext_lines = fulltext.split("\n")
-
-        for error in errors:
-            error.print_error(fulltext_lines)
-
     resources: OrderedDict[str, Resource] = resource_list.resources
     resources = expand_raw_resource(resources)
     resources = fill_default_requirement_groups(resources, resource_list.requirement_groups)
@@ -588,6 +580,14 @@ def create_calculator_page(
     # Touch the created time of all the files in the output folder to prevent
     # re-triggering generation on outdated files that were intentionally skipped
     touch_output_folder_files(calculator_folder)
+
+    if len(errors) > 0:
+        with open(resource_list_file, 'r', encoding="utf_8") as f:
+            fulltext = f.read()
+            fulltext_lines = fulltext.split("\n")
+
+        for error in errors:
+            error.print_error(fulltext_lines)
 
     end_time = time.time()
     print("  Generated in %.3f seconds" % (end_time - start_time))

--- a/build.py
+++ b/build.py
@@ -12,12 +12,12 @@ import yaml
 from typing import OrderedDict
 from jinja2 import Environment, FileSystemLoader
 from PIL import Image  # type: ignore
-from typing import Any, Dict, TextIO, Tuple, Type, List
+from typing import Any, Dict, TextIO, Tuple, Type, List, Set
 
 from pylib.json_data_compressor import mini_js_data
 from pylib.uglifyjs import uglify_copyfile, uglify_js_string
 from pylib.webminify import minify_css_blocks
-from pylib.resource_list import ResourceList, Resource, StackSize, Recipe, TokenError
+from pylib.resource_list import ResourceList, Resource, StackSize, Recipe, TokenError, Token, get_primitive
 from pylib.yaml_token_load import ordered_load
 
 
@@ -146,112 +146,52 @@ def lint_javascript() -> None:
 # and contents. In addition it makes sure that all of the required elements of
 # a recipe are present and that no additional unknown elements are present.
 ################################################################################
-def lint_recipes(calculator_name: str, item_name: str, recipes: List) -> None:
-    required_keys = ["output", "recipe_type", "requirements"]
-    optional_keys = ["extra_data"]
-
-    valid_keys = required_keys + optional_keys
-
-    for i, recipe in enumerate(recipes):
-
-        recipe_keys = [x for x in recipe]
-
-        # Make sure all the required keys exist
-        for required_key in required_keys:
-            if required_key not in recipe_keys:
-                print(calculator_name.upper() + ":", "\"" + required_key + "\" is not in", item_name, "recipe", i)
-
-        # Make sure that all the keys being used are valid keys
-        for recipe_key in recipe_keys:
-            if recipe_key not in valid_keys:
-                print(calculator_name.upper() + ":", "\"" + recipe_key + "\" in", item_name, "recipe", i, "is not a valid key")
-
-        # Validate the keys are in the right order to promote uniformity in the templates
-        if (recipe_keys[0] != valid_keys[0]):
-            # print(item_name, "recipe", i, "should have the first element of the hash be \"output\"")
-            print(calculator_name.upper() + ":", "\"output\" should be the first key of", item_name, "recipe", i)
-        if (recipe_keys[1] != valid_keys[1]):
-            # print(item_name, "recipe", i, "should have the first element of the hash be \"output\"")
-            print(calculator_name.upper() + ":", "\"recipe_type\" should be the second key of", item_name, "recipe", i)
-        if (recipe_keys[2] != valid_keys[2]):
-            # print(item_name, "recipe", i, "should have the first element of the hash be \"output\"")
-            print(calculator_name.upper() + ":", "\"requirements\" should be the third key of", item_name, "recipe", i)
+def lint_recipes(calculator_name: str, item_name: str, recipes: List[Recipe]) -> List[TokenError]:
+# def lint_recipes(calculator_name: str, item_name: str, item_token: Token, recipes: List[Recipe]) -> None:
+    errors: List[TokenError] = []
 
     # Check that every resource has a raw recipe
     raw_resource_count = 0
     for recipe in recipes:
-        if (recipe['recipe_type'] == "Raw Resource"):
-            if (recipe == OrderedDict([('output', 1), ('recipe_type', 'Raw Resource'), ('requirements', OrderedDict([(item_name, 0)]))])):
+        if (recipe.recipe_type == "Raw Resource"):
+            if (recipe.output == 1 and recipe.requirements == OrderedDict([(item_name, 0)])):
                 raw_resource_count += 1
             else:
-                print(calculator_name.upper() + ":", item_name, "has an invalid \"Raw Resource\"")
+                # TODO: Have a better token associated with this error
+                errors.append(TokenError(item_name + " has an invalid \"Raw Resource\"", Token()))
 
     # Lint that every resource has a raw resource and only one
     if raw_resource_count == 0:
-        print(calculator_name.upper() + ":", item_name, "must have a \"Raw Resource\" which outputs 1 and has a requirement of 0 of itself")
+        # TODO: Have a better token associated with this error
+        errors.append(TokenError(item_name + " must have a \"Raw Resource\" which outputs 1 and has a requirement of 0 of itself", Token()))
     elif raw_resource_count > 1:
-        print(calculator_name.upper() + ":", item_name, "must have only one \"Raw Resource\"")
+        # TODO: Have a better token associated with this error
+        errors.append(TokenError(item_name + " must have only one \"Raw Resource\"", Token()))
 
+    return errors
 
-def lint_resources(calculator_name: str, resources: OrderedDict[str, Resource], recipe_types: OrderedDict[str, str], stack_sizes: OrderedDict[str, StackSize]) -> List[TokenError]:
-    valid_keys = OrderedDict([
-        ("custom_simplename", False),
-        ("custom_stack_multipliers", False),
-        ("recipes", True),
-    ])
-
-    for resource in resources:
-        resource_keys = [x for x in resources[resource]]
-
-        # Check that all required keys are in the resource
-        for valid_key in valid_keys:
-            if valid_keys[valid_key] and valid_key not in resource_keys:
-                print(calculator_name.upper() + ":", "\"" + valid_key + "\" is not in", resource)
-
-        # Check that all keys are required or optional
-        for resource_key in resource_keys:
-            if type(resource_key) is not str:
-                print("TODOERROR: Cannot use non-string {} as key for {}".format(str(resource_key), resource))
-                continue
-            if resource_key not in valid_keys.keys():
-                print(calculator_name.upper() + ":", "\"" + resource_key + "\" in", resource, "is not a valid key")
-
-        if "recipes" not in resources[resource]:
-            print("TODOERROR: recipes not in resource", resource)
-        else:
-            lint_recipes(calculator_name, resource, resources[resource]["recipes"])
-
-        if "custom_stack_multipliers" in resources[resource]:
-            lint_custom_stack_multipliers(calculator_name, resource, resources[resource]["custom_stack_multipliers"], stack_sizes)
-
-    ensure_valid_requirements(resources)
-    ensure_valid_recipe_types(calculator_name, resources, recipe_types)
-    ensure_unique_simple_names(calculator_name, resources)
-
-
-def lint_custom_stack_multipliers(calculator_name, item_name, custom_stack_multipliers, stack_sizes):
+################################################################################
+#
+################################################################################
+def lint_custom_stack_multipliers(
+    calculator_name: str,
+    item_name: str,
+    custom_stack_multipliers: OrderedDict[str, int],
+    stack_sizes: OrderedDict[str, StackSize]
+) -> List[TokenError]:
+    errors: List[TokenError] = []
     for stack_name in custom_stack_multipliers:
         custom_size = custom_stack_multipliers[stack_name]
 
         if stack_name not in stack_sizes:
-            print(calculator_name.upper() + ":", "custom_stack_size \"" + stack_name + "\" for", item_name, "is not a valid stack size. (" + ", ".join([x for x in stack_sizes]) + ")")
+            # TODO: Have a better token associated with this error
+            errors.append(TokenError("custom_stack_size \"" + stack_name + "\" for" + item_name + "is not a valid stack size. (" + ", ".join([x for x in stack_sizes]) + ")", Token()))
 
         if custom_size < 1:
-            print(calculator_name.upper() + ":", "custom_stack_size \"" + stack_name + "\" for", item_name, "cannot be less than 1.")
+            # TODO: Have a better token associated with this error
+            errors.append(TokenError("custom_stack_size \"" + stack_name + "\" for" + item_name + "cannot be less than 1.", Token()))
 
-
-def ensure_unique_simple_names(calculator_name, resources):
-    simple_names = {}
-
-    for resource in resources:
-        simple_name = get_simple_name(resource, resources)
-        if simple_name not in simple_names:
-            simple_names[simple_name] = []
-        simple_names[simple_name].append(resource)
-
-    for simple_name in simple_names:
-        if len(simple_names[simple_name]) > 1:
-            print(calculator_name.upper() + ":", ", ".join(simple_names[simple_name]), "all share the same simple name", simple_name)
+    return errors
 
 
 ################################################################################
@@ -259,39 +199,86 @@ def ensure_unique_simple_names(calculator_name, resources):
 #
 # Make sure each recipe requirement is another existing item in the resource list
 ################################################################################
-def ensure_valid_requirements(resources):
+def ensure_valid_requirements(resources: OrderedDict[str, Resource]) -> List[TokenError]:
+    errors: List[TokenError] = []
     for resource in resources:
-        if (type(resources[resource]) is not OrderedDict):
-            print("ERROR invalid resources for", resource)
-            continue
-        for recipe in resources[resource]["recipes"]:
-            for requirement in recipe["requirements"]:
+        for recipe in resources[resource].recipes:
+            for requirement in recipe.requirements:
                 if requirement not in resources:
-                    print("ERROR: Invalid requirement for resource:", resource + ". \"" + requirement + "\" does not exist as a resource")
-                elif type(recipe["requirements"][requirement]) is not int:
-                    print("ERROR: cannot use {} as a requirement value for {}".format(recipe["requirements"][requirement], resource))
-                elif recipe["requirements"][requirement] > 0:
-                    print("ERROR: Invalid requirement for resource:", resource + ". \"" + requirement + "\" must be a negative number")
+                    # TODO: Have a better token associated with this error
+                    errors.append(TokenError("ERROR: Invalid requirement for resource:" + resource + ". \"" + requirement + "\" does not exist as a resource", Token()))
+                elif recipe.requirements[requirement] > 0:
+                    # TODO: Have a better token associated with this error
+                    errors.append(TokenError("ERROR: Invalid requirement for resource:" + resource + ". \"" + requirement + "\" must be a negative number", Token()))
+    return errors
 
 
-def ensure_valid_recipe_types(calculator_name, resources, recipe_types):
-    found_recipe_types = []
+################################################################################
+#
+################################################################################
+def ensure_valid_recipe_types(calculator_name: str, resources: OrderedDict[str, Resource], recipe_types: OrderedDict[str, str]) -> List[TokenError]:
+    used_recipe_types: Set[str] = set()
+    errors: List[TokenError] = []
+
     for resource in resources:
-        if (type(resources[resource]) is not OrderedDict):
-            print("ERROR invalid resources for", resource)
-            continue
-        for recipe in resources[resource]["recipes"]:
-            recipe_type = recipe["recipe_type"]
+        for recipe in resources[resource].recipes:
+            recipe_type: str = recipe.recipe_type
+
             # add this to the list of found recipe types to later check to make sure all the recipe_types in the list are used
-            if recipe_type not in found_recipe_types and recipe_type != "Raw Resource":
-                found_recipe_types.append(recipe_type)
+            if recipe_type != "Raw Resource":
+                used_recipe_types.add(recipe_type)
+
             # check if this recipe exists in the recipe type list
             if recipe_type not in recipe_types and recipe_type != "Raw Resource":
-                print(calculator_name.upper() + ":", resource + " has an undefined resource_type" + ": \"" + recipe_type + "\"")
+                # TODO: Have a better token associated with this error
+                errors.append(TokenError(resource + " has an undefined resource_type" + ": \"" + recipe_type + "\"", Token()))
 
     for recipe_type in recipe_types:
-        if recipe_type not in found_recipe_types:
-            print(calculator_name.upper() + ":", "Unused recipe_type \"" + recipe_type + "\"")
+        if recipe_type not in used_recipe_types:
+            errors.append(TokenError("Unused recipe_type \"" + recipe_type + "\"", Token()))
+
+    return errors
+
+
+################################################################################
+#
+################################################################################
+def ensure_unique_simple_names(calculator_name: str, resources: OrderedDict[str, Resource]) -> List[TokenError]:
+    errors: List[TokenError] = []
+    simple_names: Dict[str, List[str]] = {}
+
+    for resource in resources:
+        simple_name: str = get_simple_name(resource, resources)
+        if simple_name not in simple_names:
+            simple_names[simple_name] = []
+        simple_names[simple_name].append(resource)
+
+    for simple_name in simple_names:
+        if len(simple_names[simple_name]) > 1:
+            # TODO: Have a better token associated with this error
+            errors.append(TokenError(", ".join(simple_names[simple_name]) + "all share the same simple name" + simple_name, Token()))
+
+    return errors
+
+################################################################################
+#
+################################################################################
+def lint_resources(
+    calculator_name: str,
+    resources: OrderedDict[str, Resource],
+    recipe_types: OrderedDict[str, str],
+    stack_sizes: OrderedDict[str, StackSize]
+) -> List[TokenError]:
+    errors: List[TokenError] = []
+    for resource in resources:
+        errors += lint_recipes(calculator_name, resource, resources[resource].recipes)
+        errors += lint_custom_stack_multipliers(calculator_name, resource, resources[resource].custom_stack_multipliers, stack_sizes)
+
+    errors += ensure_valid_requirements(resources)
+    errors += ensure_valid_recipe_types(calculator_name, resources, recipe_types)
+    errors += ensure_unique_simple_names(calculator_name, resources)
+
+    return errors
 
 
 ################################################################################
@@ -300,7 +287,7 @@ def ensure_valid_recipe_types(calculator_name, resources, recipe_types):
 # This function takes a directory and finds the oldest modification time of any
 # file in that directory.
 ################################################################################
-def get_oldest_modified_time(path):
+def get_oldest_modified_time(path: str) -> float:
     time_list = []
     for file in os.listdir(path):
         filepath = os.path.join(path, file)
@@ -330,13 +317,11 @@ def get_newest_modified_time(path: str) -> float:
     return max(time_list)
 
 
-def generate_content_width_css(image_width, yaml_data):
+def generate_content_width_css(image_width: int, resource_list: ResourceList) -> str:
     content_width_css = ""
     media_padding = 40  # This give a slight padding from the edges, useful for avoiding intersection with scroll bars
-    if "row_group_count" in yaml_data:
-        row_group_count = yaml_data["row_group_count"]
-    else:
-        row_group_count = 1
+    
+    row_group_count = resource_list.row_group_count
 
     iteration = 1
     image_width_with_padding = image_width + 6  # TODO: This will need to be updated if custom styling is added to the calculator
@@ -356,9 +341,15 @@ def generate_content_width_css(image_width, yaml_data):
     return content_width_css
 
 
-def get_simple_name(resource, resources):
-    if "custom_simplename" in resources[resource]:
-        return resources[resource]["custom_simplename"]
+################################################################################
+# get_simple_name checks if a simple name override has been set for the
+# resource, and if it has then returns it. Otherwise it generates the simple
+# name from the resource's actual name.
+################################################################################
+def get_simple_name(resource: str, resources: OrderedDict[str, Resource]) -> str:
+    # TODO: Change this if we end up implementing something like "is_set()" for the YAML conversions
+    if resources[resource].custom_simplename != "":
+        return resources[resource].custom_simplename
     return re.sub(r'[^a-z0-9]', '', resource.lower())
 
 
@@ -367,7 +358,7 @@ def get_simple_name(resource, resources):
 #
 #
 ################################################################################
-def generate_resource_html_data(resources):
+def generate_resource_html_data(resources: OrderedDict[str, Resource]) -> List[Dict[str, str]]:
     resources_html_data = []
     for resource in resources:
         resource_html_data = {}
@@ -383,8 +374,8 @@ def generate_resource_html_data(resources):
 #
 #
 ################################################################################
-def generate_resource_offset_classes(resources, resource_image_coordinates):
-    item_styles = {}
+def generate_resource_offset_classes(resources: OrderedDict[str, Resource], resource_image_coordinates: Dict[str, Tuple[int, int]]) -> Dict[str, str]:
+    item_styles: Dict[str, str] = {}
     for resource in resources:
         simple_name = get_simple_name(resource, resources)
 
@@ -398,21 +389,17 @@ def generate_resource_offset_classes(resources, resource_image_coordinates):
     return item_styles
 
 
-def get_recipes_only(resources):
-    return {resource: resources[resource]["recipes"] for resource in resources}
+def get_recipes_only(resources: OrderedDict[str, Resource]) -> Dict[str, List[Recipe]]:
+    return {resource: resources[resource].recipes for resource in resources}
 
 
-def merge_custom_multipliers(stack_sizes, resources):
+def merge_custom_multipliers(stack_sizes: OrderedDict[str, StackSize], resources: OrderedDict[str, Resource]) -> OrderedDict[str, StackSize]:
     for resource in resources:
-        if "custom_stack_multipliers" in resources[resource]:
-            custom_sizes = resources[resource]["custom_stack_multipliers"]
-            for custom_size_name in custom_sizes:
-                custom_size = custom_sizes[custom_size_name]
+        custom_sizes = resources[resource].custom_stack_multipliers
+        for custom_size_name in custom_sizes:
+            custom_size = custom_sizes[custom_size_name]
 
-                if "custom_multipliers" not in stack_sizes[custom_size_name]:
-                    stack_sizes[custom_size_name]["custom_multipliers"] = OrderedDict()
-
-                stack_sizes[custom_size_name]["custom_multipliers"][resource] = custom_size
+            stack_sizes[custom_size_name].custom_multipliers[resource] = custom_size
 
     return stack_sizes
 
@@ -459,7 +446,7 @@ def touch_output_folder_files(calculator_folder: str, timestamp: int = 0) -> Non
     for file in os.listdir(calculator_folder):
         filepath = os.path.join(calculator_folder, file)
         if (os.path.isdir(filepath)):
-            get_oldest_modified_time(filepath, timestamp)
+            touch_output_folder_files(filepath, timestamp)
         else:
             os.utime(filepath, (timestamp, timestamp))
 
@@ -475,7 +462,7 @@ def create_calculator_page(
     calculator_name: str,
     force: bool = False,
     print_skip_text: bool = True
-):
+) -> None:
     errors = []
     calculator_folder = os.path.join("output", calculator_name)
     source_folder = os.path.join("resource_lists", calculator_name)
@@ -498,6 +485,7 @@ def create_calculator_page(
     print("Generating", calculator_name, "into", calculator_folder)
 
     # Create a packed image of all the item images
+    # int,       int,          Dict[str, Tuple[int, int]]
     image_width, image_height, resource_image_coordinates = create_packed_image(calculator_name)
 
     # Load in the yaml resources file
@@ -535,14 +523,9 @@ def create_calculator_page(
     #     stack_sizes = yaml_data["stack_sizes"]
     # run some sanity checks on the resources
 
-    lint_resources(calculator_name, resources, recipe_types, stack_sizes)
+    errors += lint_resources(calculator_name, resources, recipe_types, stack_sizes)
 
-    exit()
-
-
-    default_stack_size = None
-    if "default_stack_size" in yaml_data:
-        default_stack_size = yaml_data["default_stack_size"]
+    default_stack_size: str = resource_list.default_stack_size
 
     # TODO: Add linting for stack sizes here
 
@@ -550,18 +533,19 @@ def create_calculator_page(
     if not FLAG_skip_uglify_js:
         recipe_type_format_js = uglify_js_string(recipe_type_format_js)
 
-    recipe_js = mini_js_data(get_recipes_only(resources))
+    
+    recipe_js = mini_js_data(get_primitive(get_recipes_only(resources)))
 
     html_resource_data = generate_resource_html_data(resources)
 
     item_styles = generate_resource_offset_classes(resources, resource_image_coordinates)
 
     # Generate some css to allow us to center the list
-    content_width_css = generate_content_width_css(image_width, yaml_data)
+    content_width_css = generate_content_width_css(image_width, resource_list)
 
     stack_sizes = merge_custom_multipliers(stack_sizes, resources)
 
-    stack_sizes_json = json.dumps(stack_sizes)
+    stack_sizes_json = json.dumps(get_primitive(stack_sizes))
 
     # Generate the calculator from a template
     env = Environment(loader=FileSystemLoader('core'))
@@ -629,7 +613,7 @@ def create_calculator_page(
 #             }
 #         ]
 #     }]
-def generate_recipe_type_format_js(calculator_name, recipe_types):
+def generate_recipe_type_format_js(calculator_name: str, recipe_types: OrderedDict[str, str]) -> str:
     recipe_type_format_functions = []
 
     for recipe_type in recipe_types:
@@ -683,7 +667,7 @@ def generate_recipe_type_format_js(calculator_name, recipe_types):
 #
 # This function creates an index page with all of the calculator links
 ################################################################################
-def create_index_page(directories):
+def create_index_page(directories: List[str]) -> None:
     for directory in directories:
         shutil.copyfile("resource_lists/" + directory + "/icon.png", "output/" + directory + "/icon.png")
 
@@ -710,11 +694,16 @@ def create_index_page(directories):
 # calculator_display_name
 #
 # Reads the resources yaml file and grabs the display name of that calculator
+#
+# TODO: This function is very slow because it parses the entire yaml file again
+#       maybe there can be some caching that happens here.
 ################################################################################
-def calculator_display_name(calculator_name):
+def calculator_display_name(calculator_name: str) -> str:
     with open(os.path.join("resource_lists", calculator_name, "resources.yaml"), 'r', encoding="utf_8") as f:
         yaml_data = ordered_load(f)
-    return yaml_data["index_page_display_name"]
+        resource_list = ResourceList()
+        resource_list.parse(yaml_data)
+    return resource_list.index_page_display_name
 
 
 ################################################################################
@@ -826,7 +815,7 @@ def main() -> None:
     while True:
         # Create the calculators
         d = './resource_lists'
-        calculator_directories = []
+        calculator_directories: List[str] = []
         for o in os.listdir(d):
             if os.path.isdir(os.path.join(d, o)):
                 if calculator_page_sublist == [] or o in calculator_page_sublist:

--- a/build.py
+++ b/build.py
@@ -399,10 +399,16 @@ def generate_resource_offset_classes(resources: OrderedDict[str, Resource], reso
     return item_styles
 
 
+################################################################################
+#
+################################################################################
 def get_recipes_only(resources: OrderedDict[str, Resource]) -> Dict[str, List[Recipe]]:
     return {resource: resources[resource].recipes for resource in resources}
 
 
+################################################################################
+#
+################################################################################
 def merge_custom_multipliers(stack_sizes: OrderedDict[str, StackSize], resources: OrderedDict[str, Resource]) -> OrderedDict[str, StackSize]:
     for resource in resources:
         custom_sizes = resources[resource].custom_stack_multipliers
@@ -496,7 +502,9 @@ def create_calculator_page(
     print("Generating", calculator_name, "into", calculator_folder)
 
     # Create a packed image of all the item images
-    # int,       int,          Dict[str, Tuple[int, int]]
+    image_width: int
+    image_height: int
+    resource_image_coordinates: Dict[str, Tuple[int, int]]
     image_width, image_height, resource_image_coordinates = create_packed_image(calculator_name)
 
     # Load in the yaml resources file
@@ -847,6 +855,7 @@ def main() -> None:
             continue
         else:
             break
+
 
 if __name__ == "__main__":
     main()

--- a/build.py
+++ b/build.py
@@ -848,5 +848,5 @@ def main() -> None:
         else:
             break
 
-
-main()
+if __name__ == "__main__":
+    main()

--- a/build_test.py
+++ b/build_test.py
@@ -1,13 +1,13 @@
 import build
-from typing import Dict, Tuple, List, Set, OrderedDict
+from typing import List, OrderedDict
 from pylib.yaml_token_load import ordered_load
-from pylib.resource_list import ResourceList, Resource, StackSize, Recipe, TokenError, Token, get_primitive
+from pylib.resource_list import ResourceList, Resource, StackSize, TokenError, Token
 
 import unittest
 
 
-
-
+# TODO there should be a better way to handle this from the original source code
+# but that will require some refactoring first so we employ this manual method
 def test_load(input_yaml: str) -> List[TokenError]:
     errors: List[TokenError] = []
     with open(input_yaml, 'r', encoding="utf_8") as f:
@@ -26,6 +26,10 @@ def test_load(input_yaml: str) -> List[TokenError]:
 
     return errors
 
+
+################################################################################
+#
+################################################################################
 class Test_Invalid_Yaml(unittest.TestCase):
     def setUp(self) -> None:
         pass
@@ -103,5 +107,45 @@ class Test_Invalid_Yaml(unittest.TestCase):
             TokenError("recipe_types key should be a string not a <class 'int'>", Token(9, 9, 2, 6)),
             TokenError("recipe_types value should be a string not a <class 'int'>", Token(9, 9, 8, 13)),
             TokenError('Unused recipe_type "-999"', Token(0, 0, 0, 0))
+        ]
+        self.assertListEqual(errors, desired_errors)
+
+    ############################################################################
+    #
+    ############################################################################
+    def test_invalid_recipe_type(self) -> None:
+        errors = test_load("tests/invalid_recipe_type.yaml")
+        desired_errors: List[TokenError] = [
+            TokenError('MyResource has an undefined resource_type: "UnkonwnRecipeType"', Token(0, 0, 0, 0))
+        ]
+        self.assertListEqual(errors, desired_errors)
+
+    ############################################################################
+    #
+    ############################################################################
+    def test_unused_recipe_type(self) -> None:
+        errors = test_load("tests/unused_recipe_type.yaml")
+        desired_errors: List[TokenError] = [
+            TokenError('Unused recipe_type "UnusedRecipeType"', Token(0, 0, 0, 0))
+        ]
+        self.assertListEqual(errors, desired_errors)
+
+    ############################################################################
+    #
+    ############################################################################
+    def test_invalid_requirement_name(self) -> None:
+        errors = test_load("tests/invalid_requirement_name.yaml")
+        desired_errors: List[TokenError] = [
+            TokenError('ERROR: Invalid requirement for resource:MyResource. "MyMissingSubResource" does not exist as a resource', Token(0, 0, 0, 0))
+        ]
+        self.assertListEqual(errors, desired_errors)
+
+    ############################################################################
+    #
+    ############################################################################
+    def test_invalid_requirement_count(self) -> None:
+        errors = test_load("tests/invalid_requirement_count.yaml")
+        desired_errors: List[TokenError] = [
+            TokenError('ERROR: Invalid requirement for resource:MyResource. "MySubResource" must be a negative number', Token(0, 0, 0, 0))
         ]
         self.assertListEqual(errors, desired_errors)

--- a/build_test.py
+++ b/build_test.py
@@ -1,0 +1,107 @@
+import build
+from typing import Dict, Tuple, List, Set, OrderedDict
+from pylib.yaml_token_load import ordered_load
+from pylib.resource_list import ResourceList, Resource, StackSize, Recipe, TokenError, Token, get_primitive
+
+import unittest
+
+
+
+
+def test_load(input_yaml: str) -> List[TokenError]:
+    errors: List[TokenError] = []
+    with open(input_yaml, 'r', encoding="utf_8") as f:
+        yaml_data = ordered_load(f)
+        resource_list = ResourceList()
+        errors += resource_list.parse(yaml_data)
+
+    resources: OrderedDict[str, Resource] = resource_list.resources
+    resources = build.expand_raw_resource(resources)
+
+    recipe_types: OrderedDict[str, str] = resource_list.recipe_types
+
+    stack_sizes: OrderedDict[str, StackSize] = resource_list.stack_sizes
+
+    errors += build.lint_resources("TEST CALCULATOR", resources, recipe_types, stack_sizes)
+
+    return errors
+
+class Test_Invalid_Yaml(unittest.TestCase):
+    def setUp(self) -> None:
+        pass
+
+    ############################################################################
+    #
+    ############################################################################
+    def test_invalid_resource_list_key(self) -> None:
+        errors = test_load("tests/good_fields.yaml")
+        desired_errors: List[TokenError] = []
+        self.assertListEqual(errors, desired_errors)
+
+    ############################################################################
+    #
+    ############################################################################
+    def test_invalid_raw_resource_error(self) -> None:
+        errors = test_load("tests/invalid_raw_resource.yaml")
+        desired_errors: List[TokenError] = [
+            TokenError('MyResource has an invalid "Raw Resource"', Token(0, 0, 0, 0)),
+            TokenError('MyResource must have a "Raw Resource" which outputs 1 and has a requirement of 0 of itself', Token(0, 0, 0, 0))
+        ]
+        self.assertListEqual(errors, desired_errors)
+
+    ############################################################################
+    #
+    ############################################################################
+    def test_missing_raw_resource_error(self) -> None:
+        errors = test_load("tests/missing_raw_resource.yaml")
+        desired_errors: List[TokenError] = [
+            TokenError('MyResource must have a "Raw Resource" which outputs 1 and has a requirement of 0 of itself', Token(0, 0, 0, 0))
+        ]
+        self.assertListEqual(errors, desired_errors)
+
+    ############################################################################
+    #
+    ############################################################################
+    def test_invalid_resource_list_key_error(self) -> None:
+        errors = test_load("tests/invalid_resource_list_key.yaml")
+        desired_errors: List[TokenError] = [
+            TokenError(
+                "Found Invalid ResourceList key, valid ResourceList keys are ['authors', 'index_page_display_name', 'recipe_types', 'stack_sizes', 'default_stack_size', 'resources', 'game_version', 'banner_message', 'requirement_groups', 'row_group_count']",
+                Token(10, 10, 0, 16)
+            )
+        ]
+        self.assertListEqual(errors, desired_errors)
+
+    ############################################################################
+    # Test that an error is thrown when the key or value of the
+    # resource_list.authors field is not a string
+    ############################################################################
+    def test_non_string_authors_error(self) -> None:
+        errors = test_load("tests/non_string_authors.yaml")
+        desired_errors: List[TokenError] = [
+            TokenError("authors key should be a string not a <class 'int'>", Token(2, 2, 2, 4)),
+            TokenError("authors value should be a string not a <class 'int'>", Token(2, 2, 6, 12))
+        ]
+        self.assertListEqual(errors, desired_errors)
+
+    ############################################################################
+    #
+    ############################################################################
+    def test_non_string_index_display_name(self) -> None:
+        errors = test_load("tests/non_string_index_display_name.yaml")
+        desired_errors: List[TokenError] = [
+            TokenError("index_page_display_name should be a string not a <class 'int'>", Token(5, 5, 25, 27))
+        ]
+        self.assertListEqual(errors, desired_errors)
+
+    ############################################################################
+    #
+    ############################################################################
+    def test_non_string_recipe_types(self) -> None:
+        errors = test_load("tests/non_string_recipe_types.yaml")
+        desired_errors: List[TokenError] = [
+            TokenError("recipe_types key should be a string not a <class 'int'>", Token(9, 9, 2, 6)),
+            TokenError("recipe_types value should be a string not a <class 'int'>", Token(9, 9, 8, 13)),
+            TokenError('Unused recipe_type "-999"', Token(0, 0, 0, 0))
+        ]
+        self.assertListEqual(errors, desired_errors)

--- a/core/calculator.html
+++ b/core/calculator.html
@@ -119,7 +119,8 @@
 						<input type="radio" name="unit_name" id="Units {{stack_size}}" value="{{stack_size}}" {% if default_stack_size == stack_size %}checked{% endif %}><label for="Units {{stack_size}}">{{stack_sizes[stack_size].plural}}</label>
 						<!-- </div> -->
 					{% endfor %}
-					<input type="radio" name="unit_name" id="Units Single" value="" {% if default_stack_size == None %}checked{% endif %}><label for="Units Single">Single</label>
+					<input type="radio" name="unit_name" id="Units Single" value="" {% if default_stack_size == "" %}checked{% endif %}><label for="Units Single">Single</label>
+
 
 					<!-- <div class="stack_size_selector">
 						Single

--- a/presubmit.sh
+++ b/presubmit.sh
@@ -2,4 +2,4 @@
 source ./venv/bin/activate
 FILES=`find . -type f -name "*.py" -not -path "./venv/*" -not -path "./resource_lists/*"`
 flake8 --ignore=E501,E266,W503 $FILES
-# mypy --strict $FILES
+mypy --strict $FILES

--- a/presubmit.sh
+++ b/presubmit.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 source ./venv/bin/activate
 FILES=`find . -type f -name "*.py" -not -path "./venv/*" -not -path "./resource_lists/*"`
+
+# Lint Python Files
 flake8 --ignore=E501,E266,W503 $FILES
+
+# Type Check Python Files
 mypy --strict $FILES
 
-
-
-# Run Unit Tests
+# Run Python Coverage Unit Tests
 coverage run -m unittest discover -s . -p '*_test.py'
 
 # A bad attempt at integration tests by running the calculator builder over
@@ -19,4 +21,5 @@ coverage run -a build.py
 rm -r output/
 mv output.bak output
 
+# Print Code Coverage
 coverage report -m --omit='venv/*'

--- a/presubmit.sh
+++ b/presubmit.sh
@@ -3,3 +3,20 @@ source ./venv/bin/activate
 FILES=`find . -type f -name "*.py" -not -path "./venv/*" -not -path "./resource_lists/*"`
 flake8 --ignore=E501,E266,W503 $FILES
 mypy --strict $FILES
+
+
+
+# Run Unit Tests
+coverage run -m unittest discover -s . -p '*_test.py'
+
+# A bad attempt at integration tests by running the calculator builder over
+# everything. This will need to be changed in the future but is fine as an
+# interim solution.
+mv output output.bak
+coverage run -a build.py
+coverage run -a build.py --force-html
+coverage run -a build.py
+rm -r output/
+mv output.bak output
+
+coverage report -m --omit='venv/*'

--- a/pylib/json_data_compressor.py
+++ b/pylib/json_data_compressor.py
@@ -25,7 +25,7 @@ from pylib.uglifyjs import uglify_js_string
 # final file will likely be gzipped and doing more compression here would be
 # redundant and only server to make things more complex.
 ################################################################################
-def mini_js_data(data: Any) -> Any:
+def mini_js_data(data: Any) -> str:
     # This is a javascript function that gets prepended to the data so that it
     # can be decompressed on-load.
     javascript_reverser = """

--- a/pylib/json_data_compressor.py
+++ b/pylib/json_data_compressor.py
@@ -1,6 +1,6 @@
 import json
 from jinja2 import Environment
-from typing import Dict, Optional
+from typing import Dict, Optional, Any, Tuple
 
 from pylib.uglifyjs import uglify_js_string
 
@@ -25,7 +25,7 @@ from pylib.uglifyjs import uglify_js_string
 # final file will likely be gzipped and doing more compression here would be
 # redundant and only server to make things more complex.
 ################################################################################
-def mini_js_data(data: any):
+def mini_js_data(data: Any) -> Any:
     # This is a javascript function that gets prepended to the data so that it
     # can be decompressed on-load.
     javascript_reverser = """
@@ -85,7 +85,7 @@ def mini_js_data(data: any):
 # From basic testing this showed to give ~8% further decrease in size from
 # using basically random indecies
 ################################################################################
-def _mini_js_data(data):
+def _mini_js_data(data: Any) -> Tuple[Any, Any]:
     token_counts = get_token_counts(data)
     sorted_tokens = [k for k, v in sorted(token_counts.items(), key=lambda item: item[1], reverse=True)]
     token_map = {token: index for (index, token) in enumerate(sorted_tokens)}
@@ -99,28 +99,30 @@ def _mini_js_data(data):
 # This function goes through the datastructure and replaces all the tokens with
 # their index as desribed in the token_map
 ################################################################################
-def replace_data(data: any, token_map: Dict[any, int]) -> any:
+def replace_data(data: Any, token_map: Dict[Any, int]) -> Any:
     # If this node is a dictionary process each key of it and recurse the values
     if isinstance(data, dict):
-        new_data = {}
+        new_dict = {}
         for i in data:
             # Key Replacement
             key_token_index = token_map[i]
 
             # Value replacement
             element = replace_data(data[i], token_map)
-            new_data[key_token_index] = element
-
+            new_dict[key_token_index] = element
+        return new_dict
     # If this node is a list recuse each element of it
     elif isinstance(data, list):
-        new_data = []
+        new_list = []
         for i in data:
             element = replace_data(i, token_map)
-            new_data.append(element)
+            new_list.append(element)
+        return new_list
     else:
         new_data = token_map[data]
+        return new_data
 
-    return (new_data)
+    # return (new_data)
 
 
 ################################################################################
@@ -128,7 +130,7 @@ def replace_data(data: any, token_map: Dict[any, int]) -> any:
 # of a particular token so that we can know which ones are the most used and
 # which ones are the least used.
 ################################################################################
-def get_token_counts(data: any, tokens: Optional[Dict[any, int]] = None) -> Dict[any, int]:
+def get_token_counts(data: Any, tokens: Optional[Dict[Any, int]] = None) -> Dict[Any, int]:
     if tokens is None:
         tokens = {}
     # If this node is a dictionary process each key of it and recurse the values

--- a/pylib/resource_list.py
+++ b/pylib/resource_list.py
@@ -9,7 +9,13 @@ from .yaml_token_load import TokenBundle
 #
 ################################################################################
 class Token():
-    def __init__(self, start_line: int=0, end_line: int=0, start_column: int=0, end_column: int=0) -> None:
+    def __init__(
+            self,
+            start_line: int = 0,
+            end_line: int = 0,
+            start_column: int = 0,
+            end_column: int = 0
+    ) -> None:
         self.start_line: int = start_line
         self.end_line: int = end_line
         self.start_column: int = end_column
@@ -35,31 +41,39 @@ class TokenError():
         start_column = self.token.start_column
         end_column = self.token.end_column
 
-        print("Line \033[92m{}\033[0m: {}".format(
-            str(start_line_number+1),
-            self.error_string,
-        ))
+        if start_line_number == end_line_number:
+            print("Line \033[92m{}\033[0m: {}".format(
+                str(start_line_number + 1),
+                self.error_string,
+            ))
 
-        print(" │{}\033[91m{}\033[0m{}".format(
-            raw_text[start_line_number][0:start_column],
-            raw_text[start_line_number][start_column:end_column],
-            raw_text[start_line_number][end_column:],
-        ))
+            print(" │{}\033[91m{}\033[0m{}".format(
+                raw_text[start_line_number][0:start_column],
+                raw_text[start_line_number][start_column:end_column],
+                raw_text[start_line_number][end_column:],
+            ))
 
-        print(" │" + " "*(start_column) + "\033[91m"+ "^"*(end_column-start_column) + "\033[0m")
+            print(" │{}\033[91m{}\033[0m".format(
+                " " * (start_column),
+                "^" * (end_column - start_column),
+            ))
+
+        else:
+            print("Multi Line Error (Printing Not Yet Supported)")
+
 
 ################################################################################
 # A helper function to call the "to_primitive()" function on a nested series
 # of classes in order to return an object that can easily be serialized.
 ################################################################################
 def get_primitive(obj: Any) -> Any:
-    if type(obj) == list:        
+    if type(obj) == list:
         return [get_primitive(x) for x in obj]
     elif type(obj) == dict:
-        return { k: get_primitive(v) for k, v in obj.items() }
+        return {k: get_primitive(v) for k, v in obj.items()}
     elif type(obj) == OrderedDict:
         return OrderedDict([(k, get_primitive(v)) for k, v in obj.items()])
-    elif hasattr(obj,"to_primitive"):
+    elif hasattr(obj, "to_primitive"):
         return obj.to_primitive()
     else:
         return obj
@@ -68,7 +82,7 @@ def get_primitive(obj: Any) -> Any:
 ################################################################################
 #
 ################################################################################
-def _get_invalid_keys(data: Any, valid_keys: List[str]) -> List[TokenBundle]: 
+def _get_invalid_keys(data: Any, valid_keys: List[str]) -> List[TokenBundle]:
     invalid_keys: List[TokenBundle] = []
 
     for key in data:
@@ -105,7 +119,7 @@ class ResourceList():
         for invalid_key in _get_invalid_keys(tuple_tree, self.valid_keys):
             errors.append(TokenError("Found Invalid ResourceList key, valid ResourceList keys are {}".format(str(self.valid_keys)), Token().from_yaml_scalar_node(invalid_key.token)))
 
-        tokenless_keys = {k.value:v for k, v in tuple_tree.items()}
+        tokenless_keys = {k.value: v for k, v in tuple_tree.items()}
 
         # Load authors into a typed object
         if 'authors' in tokenless_keys:
@@ -122,7 +136,7 @@ class ResourceList():
         if 'index_page_display_name' in tokenless_keys:
             index_page_display_name = tokenless_keys["index_page_display_name"]
             if type(index_page_display_name.value) != str:
-                errors.append(TokenError("index_page_display_name should be a string not a {}".format(str(type(index_page_display_name.value))), Token().from_yaml_scalar_node(index_page_display_name.token)))  
+                errors.append(TokenError("index_page_display_name should be a string not a {}".format(str(type(index_page_display_name.value))), Token().from_yaml_scalar_node(index_page_display_name.token)))
 
             self.index_page_display_name = str(index_page_display_name.value)
 
@@ -152,7 +166,7 @@ class ResourceList():
         if 'default_stack_size' in tokenless_keys:
             default_stack_size = tokenless_keys["default_stack_size"]
             if type(default_stack_size.value) != str:
-                errors.append(TokenError("default_stack_size should be a string not a {}".format(str(type(default_stack_size.value))), Token().from_yaml_scalar_node(default_stack_size.token)))  
+                errors.append(TokenError("default_stack_size should be a string not a {}".format(str(type(default_stack_size.value))), Token().from_yaml_scalar_node(default_stack_size.token)))
 
             self.default_stack_size = str(default_stack_size.value)
 
@@ -171,7 +185,7 @@ class ResourceList():
         if 'game_version' in tokenless_keys:
             game_version = tokenless_keys["game_version"]
             if type(game_version.value) != str:
-                errors.append(TokenError("game_version should be a string not a {}".format(str(type(game_version.value))), Token().from_yaml_scalar_node(game_version.token)))  
+                errors.append(TokenError("game_version should be a string not a {}".format(str(type(game_version.value))), Token().from_yaml_scalar_node(game_version.token)))
 
             self.game_version = str(game_version.value)
 
@@ -179,7 +193,7 @@ class ResourceList():
         if 'banner_message' in tokenless_keys:
             banner_message = tokenless_keys["banner_message"]
             if type(banner_message.value) != str:
-                errors.append(TokenError("banner_message should be a string not a {}".format(str(type(banner_message.value))), Token().from_yaml_scalar_node(banner_message.token)))  
+                errors.append(TokenError("banner_message should be a string not a {}".format(str(type(banner_message.value))), Token().from_yaml_scalar_node(banner_message.token)))
 
             self.banner_message = str(banner_message.value)
 
@@ -204,6 +218,7 @@ class ResourceList():
 
             self.row_group_count = int(row_group_count.value)
         return errors
+
     def to_primitive(self) -> Any:
         return {
             "authors": get_primitive(self.authors),
@@ -217,6 +232,8 @@ class ResourceList():
             "requirement_groups": get_primitive(self.requirement_groups),
             "row_group_count": get_primitive(self.row_group_count),
         }
+
+
 # Class Generated with resource_list_type_generator.py
 class StackSize():
     def __init__(self) -> None:
@@ -234,7 +251,7 @@ class StackSize():
         for invalid_key in _get_invalid_keys(tuple_tree, self.valid_keys):
             errors.append(TokenError("Found Invalid StackSize key, valid StackSize keys are {}".format(str(self.valid_keys)), Token().from_yaml_scalar_node(invalid_key.token)))
 
-        tokenless_keys = {k.value:v for k, v in tuple_tree.items()}
+        tokenless_keys = {k.value: v for k, v in tuple_tree.items()}
 
         # Load quantity_multiplier into a typed object
         if 'quantity_multiplier' in tokenless_keys:
@@ -248,7 +265,7 @@ class StackSize():
         if 'plural' in tokenless_keys:
             plural = tokenless_keys["plural"]
             if type(plural.value) != str:
-                errors.append(TokenError("plural should be a string not a {}".format(str(type(plural.value))), Token().from_yaml_scalar_node(plural.token)))  
+                errors.append(TokenError("plural should be a string not a {}".format(str(type(plural.value))), Token().from_yaml_scalar_node(plural.token)))
 
             self.plural = str(plural.value)
 
@@ -272,6 +289,7 @@ class StackSize():
 
                 self.custom_multipliers[str(key.value)] = int(value.value)
         return errors
+
     def to_primitive(self) -> Any:
         return {
             "quantity_multiplier": get_primitive(self.quantity_multiplier),
@@ -279,6 +297,8 @@ class StackSize():
             "extends_from": get_primitive(self.extends_from),
             "custom_multipliers": get_primitive(self.custom_multipliers),
         }
+
+
 # Class Generated with resource_list_type_generator.py
 class Resource():
     def __init__(self) -> None:
@@ -295,11 +315,10 @@ class Resource():
         for invalid_key in _get_invalid_keys(tuple_tree, self.valid_keys):
             errors.append(TokenError("Found Invalid Resource key, valid Resource keys are {}".format(str(self.valid_keys)), Token().from_yaml_scalar_node(invalid_key.token)))
 
-        tokenless_keys = {k.value:v for k, v in tuple_tree.items()}
+        tokenless_keys = {k.value: v for k, v in tuple_tree.items()}
 
         # Load recipes into a typed object
         if 'recipes' in tokenless_keys:
-            item_list: List[str] = []
             for item in tokenless_keys['recipes']:
                 recipe = Recipe()
                 errors += recipe.parse(item)
@@ -320,16 +339,19 @@ class Resource():
         if 'custom_simplename' in tokenless_keys:
             custom_simplename = tokenless_keys["custom_simplename"]
             if type(custom_simplename.value) != str:
-                errors.append(TokenError("custom_simplename should be a string not a {}".format(str(type(custom_simplename.value))), Token().from_yaml_scalar_node(custom_simplename.token)))  
+                errors.append(TokenError("custom_simplename should be a string not a {}".format(str(type(custom_simplename.value))), Token().from_yaml_scalar_node(custom_simplename.token)))
 
             self.custom_simplename = str(custom_simplename.value)
         return errors
+
     def to_primitive(self) -> Any:
         return {
             "recipes": get_primitive(self.recipes),
             "custom_stack_multipliers": get_primitive(self.custom_stack_multipliers),
             "custom_simplename": get_primitive(self.custom_simplename),
         }
+
+
 # Class Generated with resource_list_type_generator.py
 class Recipe():
     def __init__(self) -> None:
@@ -346,7 +368,7 @@ class Recipe():
         for invalid_key in _get_invalid_keys(tuple_tree, self.valid_keys):
             errors.append(TokenError("Found Invalid Recipe key, valid Recipe keys are {}".format(str(self.valid_keys)), Token().from_yaml_scalar_node(invalid_key.token)))
 
-        tokenless_keys = {k.value:v for k, v in tuple_tree.items()}
+        tokenless_keys = {k.value: v for k, v in tuple_tree.items()}
 
         # Load output into a typed object
         if 'output' in tokenless_keys:
@@ -360,7 +382,7 @@ class Recipe():
         if 'recipe_type' in tokenless_keys:
             recipe_type = tokenless_keys["recipe_type"]
             if type(recipe_type.value) != str:
-                errors.append(TokenError("recipe_type should be a string not a {}".format(str(type(recipe_type.value))), Token().from_yaml_scalar_node(recipe_type.token)))  
+                errors.append(TokenError("recipe_type should be a string not a {}".format(str(type(recipe_type.value))), Token().from_yaml_scalar_node(recipe_type.token)))
 
             self.recipe_type = str(recipe_type.value)
 
@@ -375,6 +397,7 @@ class Recipe():
 
                 self.requirements[str(key.value)] = int(value.value)
         return errors
+
     def to_primitive(self) -> Any:
         return {
             "output": get_primitive(self.output),

--- a/pylib/resource_list.py
+++ b/pylib/resource_list.py
@@ -43,10 +43,12 @@ class Token():
         if type(other) != Token:
             return False
 
-        if (other.start_line == self.start_line
+        if (
+            other.start_line == self.start_line
             and other.end_line == self.end_line
             and other.start_column == self.start_column
-            and other.end_column == self.end_column):
+            and other.end_column == self.end_column
+        ):
             return True
         return False
 

--- a/pylib/resource_list.py
+++ b/pylib/resource_list.py
@@ -1,0 +1,312 @@
+from typing import List, Optional, Any
+import yaml
+from collections import OrderedDict
+
+from .yaml_token_load import TokenBundle
+
+
+################################################################################
+#
+################################################################################
+class TokenError():
+    def __init__(self, error_string: str, token: yaml.nodes.ScalarNode) -> None:
+        self.error_string: str = error_string
+        self.token: yaml.nodes.ScalarNode = token
+
+    def print_error(self, raw_text: List[str]) -> None:
+        start_line_number = self.token.start_mark.line
+        end_line_number = self.token.end_mark.line
+
+        start_column = self.token.start_mark.column
+        end_column = self.token.end_mark.column
+
+        print("Line \033[92m{}\033[0m: {}".format(
+            str(start_line_number+1),
+            self.error_string,
+        ))
+
+        print(" │{}\033[91m{}\033[0m{}".format(
+            raw_text[start_line_number][0:start_column],
+            raw_text[start_line_number][start_column:end_column],
+            raw_text[start_line_number][end_column:],
+        ))
+
+        print(" │" + " "*(start_column) + "\033[91m"+ "^"*(end_column-start_column) + "\033[0m")
+
+
+################################################################################
+#
+################################################################################
+class ResourceList():
+    def __init__(self) -> None:
+        self.authors: OrderedDict[str, str] = OrderedDict()
+        self.index_page_display_name: str = ""
+        self.recipe_types: OrderedDict[str, str] = OrderedDict()
+        self.stack_sizes: OrderedDict[str, StackSize] = OrderedDict()
+        self.default_stack_size: str = ""
+        self.resources: OrderedDict[str, Resource] = OrderedDict()
+        self.game_version: str = ""
+        self.banner_message: str = ""
+        self.requirement_groups: OrderedDict[str, List[str]] = OrderedDict()
+
+        # This is a bit of a hack to identify all the variables declared
+        # previously to avoid having to keep to lists of objects in-sync
+        self.valid_keys = [attr for attr in dir(self) if not callable(getattr(self, attr)) and not attr.startswith("__")]
+
+    def parse(self, tuple_tree: Any) -> List[TokenError]:
+        errors: List[TokenError] = []
+
+        # invalid keys
+        for invalid_key in _get_invalid_keys(tuple_tree, self.valid_keys):
+            errors.append(TokenError("Found invalid resource_list key, valid resource_list are " + str(self.valid_keys), invalid_key.token))
+
+        tokenless_keys = {k.value:v  for k,v in tuple_tree.items()}
+
+        # Load the authors field into a typed object
+        if "authors" in tokenless_keys:
+            for author, link in tokenless_keys["authors"].items():
+                if type(author.value) != str:
+                    errors.append(TokenError("Author should be a string not a " + str(type(author.value)), author.token))
+
+                if type(link.value) != str:
+                    errors.append(TokenError("Author Link should be a string not a " + str(type(link.value)), link.token))
+
+                self.authors[str(author.value)] = str(link.value)
+
+        # load the index page display name into a typed object
+        if "index_page_display_name" in tokenless_keys:
+            index_page_display_name = tokenless_keys["index_page_display_name"]
+            if type(index_page_display_name.value) != str:
+                errors.append(TokenError("index_page_display_name should be a string not a " + str(type(index_page_display_name.value)), index_page_display_name.token))
+            self.index_page_display_name = str(index_page_display_name)
+        else:
+            # TOOD better tokenless errors
+            print("ERROR: Missing Key index_page_display_name")
+
+        # Load the recipe type strings into a typed object
+        if "recipe_types" in tokenless_keys:
+            for recipe_type, text in tokenless_keys["recipe_types"].items():
+                if type(recipe_type.value) != str:
+                    errors.append(TokenError("Recipe Type name should be a string not a " + str(type(recipe_type.value)), recipe_type.token))
+
+                if type(text.value) != str:
+                    errors.append(TokenError("Recipe Type instructions should be a string not a " + str(type(text.value)), text.token))
+
+                self.recipe_types[str(recipe_type.value)] = str(text.value)
+        else:
+            # TODO better tokenless errors
+            print("ERROR: Missing key recipe_types")
+
+
+        # Load stack sizes
+        if "stack_sizes" in tokenless_keys:
+            for stack_name, stack_data in tokenless_keys["stack_sizes"].items():
+                if type(stack_name.value) != str:
+                    errors.append(TokenError("Stack Size name should be a string not a " + str(type(stack_name.value)), stack_name.token))
+
+                stack_size = StackSize()
+                errors += stack_size.parse(stack_data)
+
+                self.stack_sizes[str(stack_name.value)] = stack_size
+
+        if "default_stack_size" in tokenless_keys:
+            default_stack_size = tokenless_keys["default_stack_size"]
+            if type(default_stack_size.value) != str:
+                errors.append(TokenError("default_stack_size should be a string not a " + str(type(default_stack_size.value)), default_stack_size.token))
+            self.default_stack_size = str(default_stack_size)
+
+        
+        if "resources" in tokenless_keys:
+            for resource_name, resource_data in tokenless_keys["resources"].items():
+                if type(resource_name.value) != str:
+                    errors.append(TokenError("Stack Size name should be a string not a " + str(type(resource_name.value)), resource_name.token))
+
+                resource = Resource()
+                errors += resource.parse(resource_data)
+
+                self.resources[str(resource_name.value)] = resource
+
+        if "game_version" in tokenless_keys:
+            game_version = tokenless_keys["game_version"]
+            if type(game_version.value) != str:
+                errors.append(TokenError("game_version should be a string not a " + str(type(game_version.value)), game_version.token))
+            self.game_version = str(game_version)
+
+
+        if "banner_message" in tokenless_keys:
+            banner_message = tokenless_keys["banner_message"]
+            if type(banner_message.value) != str:
+                errors.append(TokenError("banner_message should be a string not a " + str(type(banner_message.value)), banner_message.token))
+            self.banner_message = str(banner_message)
+
+
+        if "requirement_groups" in tokenless_keys:
+            for requirement_group, item_list in tokenless_keys["requirement_groups"].items():
+                if type(requirement_group.value) != str:
+                    errors.append(TokenError("Requirement Group name should be a string not a " + str(type(requirement_group.value)), requirement_group.token))
+
+                requirement_group_items: List[str] = []
+                for item in item_list:
+                    if type(item.value) != str:
+                        errors.append(TokenError("Requirement Group item should be a string not a " + str(type(item.value)), item.token))
+
+                    requirement_group_items.append(str(item.value))
+                self.requirement_groups[str(requirement_group.value)] = requirement_group_items
+        return errors
+
+
+################################################################################
+#
+################################################################################
+class StackSize():
+    def __init__(self) -> None:
+        self.quantity_multiplier: int = 0
+        self.plural: str = ""
+        self.extends_from: Optional[str] = None
+
+        # This is a bit of a hack to identify all the variables declared
+        # previously to avoid having to keep to lists of objects in-sync
+        self.valid_keys = [attr for attr in dir(self) if not callable(getattr(self, attr)) and not attr.startswith("__")]
+
+
+    def parse(self, tuple_tree: Any) -> List[TokenError]:
+        errors: List[TokenError] = []
+
+        # invalid keys
+        for invalid_key in _get_invalid_keys(tuple_tree, self.valid_keys):
+            errors.append(TokenError("Found invalid resource_list key, valid resource_list are " + str(self.valid_keys), invalid_key[1]))
+
+        tokenless_keys = {k.value:v  for k,v in tuple_tree.items()}
+
+        if "quantity_multiplier" in tokenless_keys:
+            quantity_multiplier = tokenless_keys["quantity_multiplier"]
+            if type(quantity_multiplier.value) != int:
+                errors.append(TokenError("quantity_multiplier should be a int not a " + str(type(quantity_multiplier.value)), quantity_multiplier.token))
+            self.quantity_multiplier = int(quantity_multiplier.value)
+        else:
+            # TODO better tokenless errors
+            print("ERROR: Missing key quantity_multiplier")
+
+        if "plural" in tokenless_keys:
+            plural = tokenless_keys["plural"]
+            if type(plural.value) != str:
+                errors.append(TokenError("plural should be a string not a " + str(type(plural.value)), plural.token))
+            self.plural = str(plural.value)
+        else:
+            # TODO better tokenless errors
+            print("ERROR: Missing key plural")
+
+        if "extends_from" in tokenless_keys:
+            extends_from = tokenless_keys["extends_from"]
+
+            if extends_from.value is not None:
+                if type(extends_from.value) != str:
+                    errors.append(TokenError("extends_from should be a string not a " + str(type(extends_from.value)), extends_from.token))
+                self.extends_from = str(extends_from.value)
+        else:
+            # TODO better tokenless errors
+            print("ERROR: Missing key extends_from")
+
+        return errors
+
+
+################################################################################
+#
+################################################################################
+class Resource():
+    def __init__(self) -> None:
+        self.recipes: List[Recipe] = []
+        self.custom_stack_multipliers: OrderedDict[str, int] = OrderedDict()
+
+        # This is a bit of a hack to identify all the variables declared
+        # previously to avoid having to keep to lists of objects in-sync
+        self.valid_keys = [attr for attr in dir(self) if not callable(getattr(self, attr)) and not attr.startswith("__")]
+
+    def parse(self, tuple_tree: Any) -> List[TokenError]:
+        errors: List[TokenError] = []
+
+        # invalid keys
+        for invalid_key in _get_invalid_keys(tuple_tree, self.valid_keys):
+            errors.append(TokenError("Found invalid resource_list key, valid resource_list are " + str(self.valid_keys), invalid_key[1]))
+
+        tokenless_keys = {k.value:v  for k,v in tuple_tree.items()}
+
+        if "recipes" in tokenless_keys:
+            for recipe_data in tokenless_keys["recipes"]:
+                recipe = Recipe()
+                errors += recipe.parse(recipe_data)
+                self.recipes.append(recipe)
+
+        if "custom_stack_multipliers" in tokenless_keys:
+            for custom_stack, stack_quantity in tokenless_keys["custom_stack_multipliers"].items():
+                if type(custom_stack.value) != str:
+                    errors.append(TokenError("Custom Stack name should be a string not a " + str(type(custom_stack.value)), custom_stack.token))
+
+                if type(stack_quantity.value) != int:
+                    errors.append(TokenError("Stack Quantity should be an int not a " + str(type(stack_quantity.value)), stack_quantity.token))
+
+                self.custom_stack_multipliers[str(custom_stack.value)] = int(stack_quantity.value)
+
+        return errors
+
+
+################################################################################
+#
+################################################################################
+class Recipe():
+    def __init__(self) -> None:
+        self.output: int = 0
+        self.recipe_type: str = ""
+        self.requirements: OrderedDict[str, int] = OrderedDict()
+        self.extra_data = None # DEPRICATED FIELD
+
+        # This is a bit of a hack to identify all the variables declared
+        # previously to avoid having to keep to lists of objects in-sync
+        self.valid_keys = [attr for attr in dir(self) if not callable(getattr(self, attr)) and not attr.startswith("__")]
+
+    def parse(self, tuple_tree: Any) -> List[TokenError]:
+        errors: List[TokenError] = []
+
+        # invalid keys
+        for invalid_key in _get_invalid_keys(tuple_tree, self.valid_keys):
+            errors.append(TokenError("Found invalid resource_list key, valid resource_list are " + str(self.valid_keys), invalid_key[1]))
+
+        tokenless_keys = {k.value:v  for k,v in tuple_tree.items()}
+
+        if "output" in tokenless_keys:
+            output = tokenless_keys["output"]
+            if type(output.value) != int:
+                errors.append(TokenError("output should be an int not a " + str(type(output.value)), output.token))
+            self.output = int(output.value)
+
+        if "recipe_type" in tokenless_keys:
+            recipe_type = tokenless_keys["recipe_type"]
+            if type(recipe_type.value) != str:
+                errors.append(TokenError("recipe_type should be a string not a " + str(type(recipe_type.value)), recipe_type.token))
+            self.recipe_type = str(recipe_type.value)
+
+        if "requirements" in tokenless_keys:
+            for item, quantity in tokenless_keys["requirements"].items():
+                if type(item.value) != str:
+                    errors.append(TokenError("Custom Stack name should be a string not a " + str(type(item.value)), item.token))
+
+                if type(quantity.value) != int:
+                    errors.append(TokenError("Stack Quantity should be an int not a " + str(type(quantity.value)), quantity.token))
+
+                self.requirements[str(item.value)] = int(quantity.value)
+
+
+        return errors
+
+
+################################################################################
+#
+################################################################################
+def _get_invalid_keys(data: Any, valid_keys: List[str]) -> List[TokenBundle]: 
+    invalid_keys: List[TokenBundle] = []
+
+    for key in data:
+        if key.value not in valid_keys:
+            invalid_keys.append(key)
+
+    return invalid_keys

--- a/pylib/resource_list.py
+++ b/pylib/resource_list.py
@@ -28,6 +28,28 @@ class Token():
         self.end_column = token.end_mark.column
         return self
 
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return "Token({}, {}, {}, {})".format(
+            str(self.start_line),
+            str(self.end_line),
+            str(self.start_column),
+            str(self.end_column),
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        if type(other) != Token:
+            return False
+
+        if (other.start_line == self.start_line
+            and other.end_line == self.end_line
+            and other.start_column == self.start_column
+            and other.end_column == self.end_column):
+            return True
+        return False
+
 
 class TokenError():
     def __init__(self, error_string: str, token: Token) -> None:
@@ -60,6 +82,19 @@ class TokenError():
 
         else:
             print("Multi Line Error (Printing Not Yet Supported)")
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return "TokenError(" + repr(self.error_string) + ", " + str(self.token) + ")"
+
+    def __eq__(self, other: Any) -> bool:
+        if type(other) != TokenError:
+            return False
+        if self.error_string == other.error_string and self.token == other.token:
+            return True
+        return False
 
 
 ################################################################################

--- a/pylib/resource_list.py
+++ b/pylib/resource_list.py
@@ -18,7 +18,7 @@ class Token():
     ) -> None:
         self.start_line: int = start_line
         self.end_line: int = end_line
-        self.start_column: int = end_column
+        self.start_column: int = start_column
         self.end_column: int = end_column
 
     def from_yaml_scalar_node(self, token: yaml.nodes.ScalarNode) -> 'Token':

--- a/pylib/uglifyjs.py
+++ b/pylib/uglifyjs.py
@@ -27,3 +27,4 @@ def uglify_js_string(js_string: str) -> str:
     except Exception as e:
         print("WARNING: Javascript compression failed")
         print("        ", e)
+    return js_string

--- a/pylib/webminify.py
+++ b/pylib/webminify.py
@@ -1,9 +1,9 @@
-import csscompressor
+import csscompressor  # type: ignore
 import re
 from typing import Tuple, List
 
 
-def minify_css_blocks(html_code: str) -> List[Tuple[int, int]]:
+def minify_css_blocks(html_code: str) -> str:
     remaining_code = html_code
 
     start_tag = re.compile(r"<\s*style[^>]*>")

--- a/pylib/webminify.py
+++ b/pylib/webminify.py
@@ -1,6 +1,5 @@
 import csscompressor  # type: ignore
 import re
-from typing import Tuple, List
 
 
 def minify_css_blocks(html_code: str) -> str:

--- a/pylib/webminify_test.py
+++ b/pylib/webminify_test.py
@@ -1,0 +1,28 @@
+from .webminify import minify_css_blocks
+import unittest
+import sys
+import io
+
+
+class Test_Minify(unittest.TestCase):
+
+    ############################################################################
+    # Test that a simple html block can be parsed and compressed
+    ############################################################################
+    def test_minify(self) -> None:
+        output = minify_css_blocks("<html><style>body:{ background: #CCC; }</style></html>")
+        self.assertEqual(output, "<html><style>body:{background:#CCC}</style></html>")
+
+    ############################################################################
+    # Test that a warning is printed when the end </style> tag cannot be found
+    ############################################################################
+    def test_minify_closing_style_tag_missing(self) -> None:
+        input_html = "<html><style>body:{ background: #CCC; }</html>"
+
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        output = minify_css_blocks(input_html)
+        sys.stdout = sys.__stdout__
+
+        self.assertEqual(output, input_html)
+        self.assertEqual(captured_output.getvalue(), "ERROR IN CALCULATOR TEMPLATE: No Closing </style> tag found\n")

--- a/pylib/yaml_token_load.py
+++ b/pylib/yaml_token_load.py
@@ -1,0 +1,112 @@
+from collections import OrderedDict
+from typing import Any, Dict, TextIO, Tuple, Type, List, Any
+from typing import NamedTuple
+import yaml
+
+
+
+class TokenBundle(NamedTuple):
+    value: Any
+    token: yaml.nodes.ScalarNode
+
+
+
+def tuple_string_constructor(loader: Any, node: yaml.nodes.ScalarNode) -> TokenBundle:
+    return TokenBundle(loader.construct_yaml_str(node), node)
+
+def tuple_null_constructor(loader: Any, node: yaml.nodes.ScalarNode) -> TokenBundle:
+    return TokenBundle(loader.construct_yaml_null(node), node)
+
+def tupe_int_constructor(loader: Any, node: yaml.nodes.ScalarNode) -> TokenBundle:
+    return TokenBundle(loader.construct_yaml_int(node), node)
+
+
+def placeholder_constructor(loader: Any, node: yaml.nodes.ScalarNode) -> None:
+    print("ERROR: YAML Element Found For Placeholder Constructor", node)
+
+
+################################################################################
+# ordered_load
+#
+# This function will load in the yaml recipe file but maintain the order of the
+# items. This allows us to simplify the file definition making it easier for
+# humans to use while also allowing us to set the order of the items for easy
+# grouping
+################################################################################
+def ordered_load(stream: TextIO, object_pairs_hook: Type[object] = OrderedDict) -> Any:
+    class OrderedLoader(yaml.SafeLoader):
+        pass
+
+    # Ordered Load
+    def construct_mapping(loader, node):  # type: ignore
+        loader.flatten_mapping(node)
+        pairs = loader.construct_pairs(node)
+        return object_pairs_hook(pairs)  # type: ignore
+
+    OrderedLoader.add_constructor(  # type: ignore
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+
+
+    # Tokenized Load
+    OrderedLoader.add_constructor(
+        'tag:yaml.org,2002:null',
+        tuple_null_constructor)
+
+    OrderedLoader.add_constructor(
+        'tag:yaml.org,2002:bool',
+        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        # SafeConstructor.construct_yaml_bool)
+
+    OrderedLoader.add_constructor(
+        'tag:yaml.org,2002:int',
+        tupe_int_constructor)
+
+    OrderedLoader.add_constructor(
+        'tag:yaml.org,2002:float',
+        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        # SafeConstructor.construct_yaml_float)
+
+    OrderedLoader.add_constructor(
+        'tag:yaml.org,2002:binary',
+        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        # SafeConstructor.construct_yaml_binary)
+
+    OrderedLoader.add_constructor(
+        'tag:yaml.org,2002:timestamp',
+        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        # SafeConstructor.construct_yaml_timestamp)
+
+    OrderedLoader.add_constructor(
+        'tag:yaml.org,2002:omap',
+        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        # SafeConstructor.construct_yaml_omap)
+
+    OrderedLoader.add_constructor(
+        'tag:yaml.org,2002:pairs',
+        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        # SafeConstructor.construct_yaml_pairs)
+
+    OrderedLoader.add_constructor(
+        'tag:yaml.org,2002:set',
+        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        # SafeConstructor.construct_yaml_set)
+
+    OrderedLoader.add_constructor(
+        'tag:yaml.org,2002:str',
+        tuple_string_constructor)
+
+    # No need to overwrite the Array and Map nodes
+    # OrderedLoader.add_constructor(
+    #         'tag:yaml.org,2002:seq',
+    #         SafeConstructor.construct_yaml_seq)
+
+    # OrderedLoader.add_constructor(
+    #         'tag:yaml.org,2002:map',
+    #         SafeConstructor.construct_yaml_map)
+
+    OrderedLoader.add_constructor(None,
+        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        # SafeConstructor.construct_undefined)
+
+    return yaml.load(stream, OrderedLoader)

--- a/pylib/yaml_token_load.py
+++ b/pylib/yaml_token_load.py
@@ -1,8 +1,7 @@
 from collections import OrderedDict
-from typing import Any, Dict, TextIO, Tuple, Type, List, Any
+from typing import Any, TextIO, Type
 from typing import NamedTuple
 import yaml
-
 
 
 class TokenBundle(NamedTuple):
@@ -10,12 +9,13 @@ class TokenBundle(NamedTuple):
     token: yaml.nodes.ScalarNode
 
 
-
 def tuple_string_constructor(loader: Any, node: yaml.nodes.ScalarNode) -> TokenBundle:
     return TokenBundle(loader.construct_yaml_str(node), node)
 
+
 def tuple_null_constructor(loader: Any, node: yaml.nodes.ScalarNode) -> TokenBundle:
     return TokenBundle(loader.construct_yaml_null(node), node)
+
 
 def tupe_int_constructor(loader: Any, node: yaml.nodes.ScalarNode) -> TokenBundle:
     return TokenBundle(loader.construct_yaml_int(node), node)
@@ -47,54 +47,63 @@ def ordered_load(stream: TextIO, object_pairs_hook: Type[object] = OrderedDict) 
         yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
         construct_mapping)
 
-
     # Tokenized Load
     OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:null',
-        tuple_null_constructor)
+        tuple_null_constructor
+    )
 
     OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:bool',
-        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        placeholder_constructor  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_bool)
+    )
 
     OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:int',
-        tupe_int_constructor)
+        tupe_int_constructor
+    )
 
     OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:float',
-        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        placeholder_constructor  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_float)
+    )
 
     OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:binary',
-        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        placeholder_constructor  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_binary)
+    )
 
     OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:timestamp',
-        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        placeholder_constructor  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_timestamp)
+    )
 
     OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:omap',
-        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        placeholder_constructor  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_omap)
+    )
 
     OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:pairs',
-        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        placeholder_constructor  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_pairs)
+    )
 
     OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:set',
-        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        placeholder_constructor  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_set)
+    )
 
     OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:str',
-        tuple_string_constructor)
+        tuple_string_constructor
+    )
 
     # No need to overwrite the Array and Map nodes
     # OrderedLoader.add_constructor(  # type: ignore
@@ -107,7 +116,8 @@ def ordered_load(stream: TextIO, object_pairs_hook: Type[object] = OrderedDict) 
 
     OrderedLoader.add_constructor(  # type: ignore
         None,
-        placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
+        placeholder_constructor  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_undefined)
+    )
 
     return yaml.load(stream, OrderedLoader)

--- a/pylib/yaml_token_load.py
+++ b/pylib/yaml_token_load.py
@@ -49,63 +49,64 @@ def ordered_load(stream: TextIO, object_pairs_hook: Type[object] = OrderedDict) 
 
 
     # Tokenized Load
-    OrderedLoader.add_constructor(
+    OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:null',
         tuple_null_constructor)
 
-    OrderedLoader.add_constructor(
+    OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:bool',
         placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_bool)
 
-    OrderedLoader.add_constructor(
+    OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:int',
         tupe_int_constructor)
 
-    OrderedLoader.add_constructor(
+    OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:float',
         placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_float)
 
-    OrderedLoader.add_constructor(
+    OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:binary',
         placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_binary)
 
-    OrderedLoader.add_constructor(
+    OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:timestamp',
         placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_timestamp)
 
-    OrderedLoader.add_constructor(
+    OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:omap',
         placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_omap)
 
-    OrderedLoader.add_constructor(
+    OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:pairs',
         placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_pairs)
 
-    OrderedLoader.add_constructor(
+    OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:set',
         placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_yaml_set)
 
-    OrderedLoader.add_constructor(
+    OrderedLoader.add_constructor(  # type: ignore
         'tag:yaml.org,2002:str',
         tuple_string_constructor)
 
     # No need to overwrite the Array and Map nodes
-    # OrderedLoader.add_constructor(
+    # OrderedLoader.add_constructor(  # type: ignore
     #         'tag:yaml.org,2002:seq',
     #         SafeConstructor.construct_yaml_seq)
 
-    # OrderedLoader.add_constructor(
+    # OrderedLoader.add_constructor(  # type: ignore
     #         'tag:yaml.org,2002:map',
     #         SafeConstructor.construct_yaml_map)
 
-    OrderedLoader.add_constructor(None,
+    OrderedLoader.add_constructor(  # type: ignore
+        None,
         placeholder_constructor)  # TODO: Maybe Add TokenBundle Wrapper
         # SafeConstructor.construct_undefined)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Jinja2==3.0.1
 mypy==0.902
 Pillow==8.2.0
 PyYAML==5.4.1
+types-PyYAML==5.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-Brotli==1.0.7
+coverage==5.5
 csscompressor==0.9.5
+flake8==3.9.2
 htmlmin==0.1.12
-Jinja2==2.11.3
-MarkupSafe==1.1.1
+Jinja2==3.0.1
+mypy==0.902
 Pillow==8.2.0
-PyYAML==5.4
+PyYAML==5.4.1

--- a/resource_lists/minecraft/resources.yaml
+++ b/resource_lists/minecraft/resources.yaml
@@ -4159,8 +4159,7 @@ resources:
       recipe_type: Crafting
       requirements:
         Bone Meal: -9
-    - output: 1
-      recipe_type: Raw Resource
+    - recipe_type: Raw Resource
 
   Shulker Box:
     recipes:
@@ -4595,8 +4594,7 @@ resources:
         Sand: -4
         Gravel: -4
         White Dye: -1
-    - output: 1
-      recipe_type: Raw Resource
+    - recipe_type: Raw Resource
 
   Orange Concrete Powder:
     recipes:
@@ -5474,8 +5472,7 @@ resources:
       requirements:
         Cobblestone: -7
         Redstone Dust: -1
-    - output: 1
-      recipe_type: Raw Resource
+    - recipe_type: Raw Resource
 
   Lectern:
     recipes:

--- a/resource_lists/minecraft/resources.yaml
+++ b/resource_lists/minecraft/resources.yaml
@@ -1504,10 +1504,6 @@ resources:
       requirements:
         Red Sand: -1
         Fuel: -1
-      extra_data:
-        recipe:
-        - Red Sand
-        - Fuel
     - recipe_type: Raw Resource
 
   Tinted Glass:
@@ -7285,10 +7281,6 @@ resources:
       requirements:
         Cactus: -1
         Fuel: -1
-      extra_data:
-        recipe:
-        - Cactus
-        - Fuel
     - recipe_type: Raw Resource
 
   Red Dye:

--- a/resource_lists/nier automata/resources.yaml
+++ b/resource_lists/nier automata/resources.yaml
@@ -4,7 +4,6 @@ authors:
 
 index_page_display_name: "Nier Automata"
 row_group_count: 4
-beta_page: false
 
 recipe_types:
   Upgrade: "Upgrade {IN_ITEMS} into {OUT_ITEM}"

--- a/scripts/resource_list_type_generator.py
+++ b/scripts/resource_list_type_generator.py
@@ -1,19 +1,23 @@
 import sys
 from typing import List
 
+
 class Variable():
-    def __init__(self,
+    def __init__(
+        self,
         name: str,
-        type: str, # This is incorrect but I dont know yet what it should be yet
-        default: str, # This is probably redunatnt
+        type: str,
+        default: str,
         # required: bool = False,
-    ):
+    ) -> None:
         self.name = name
         self.type = type
         self.default = default
 
 
 def generate_class(classname: str, variables: List[Variable]) -> None:
+    print()
+    print()
     print("# Class Generated with resource_list_type_generator.py")
     print("class {}():".format(classname))
     print("    def __init__(self) -> None:")
@@ -31,7 +35,7 @@ def generate_class(classname: str, variables: List[Variable]) -> None:
     print("        for invalid_key in _get_invalid_keys(tuple_tree, self.valid_keys):")
     print("            errors.append(TokenError(\"Found Invalid {name} key, valid {name} keys are {{}}\".format(str(self.valid_keys)), Token().from_yaml_scalar_node(invalid_key.token)))".format(name=classname))
     print("")
-    print("        tokenless_keys = {k.value:v for k, v in tuple_tree.items()}")
+    print("        tokenless_keys = {k.value: v for k, v in tuple_tree.items()}")
 
     for variable in variables:
         varblock = []
@@ -43,7 +47,7 @@ def generate_class(classname: str, variables: List[Variable]) -> None:
         if variable.type == "str":
             varblock.append("            {name} = tokenless_keys[\"{name}\"]")
             varblock.append("            if type({name}.value) != str:")
-            varblock.append("                errors.append(TokenError(\"{name} should be a string not a {{}}\".format(str(type({name}.value))), Token().from_yaml_scalar_node({name}.token)))  ")
+            varblock.append("                errors.append(TokenError(\"{name} should be a string not a {{}}\".format(str(type({name}.value))), Token().from_yaml_scalar_node({name}.token)))")
             varblock.append("")
             varblock.append("            self.{name} = str({name}.value)")
         elif variable.type == "Optional[str]":
@@ -70,10 +74,10 @@ def generate_class(classname: str, variables: List[Variable]) -> None:
                 varblock.append("")
                 varblock.append("                self.{name}[str(key.value)] = int(value.value)")
             elif variable.type == "OrderedDict[str, StackSize]":
-                varblock += subobject_parse("StackSize");
+                varblock += subobject_parse("StackSize")
 
             elif variable.type == "OrderedDict[str, Resource]":
-                varblock += subobject_parse("Resource");
+                varblock += subobject_parse("Resource")
 
             elif variable.type == "OrderedDict[str, List[str]]":
                 varblock.append("                item_list: List[str] = []")
@@ -91,12 +95,10 @@ def generate_class(classname: str, variables: List[Variable]) -> None:
             varblock.append("")
             varblock.append("            self.{name} = int({name}.value)")
         elif variable.type == "List[Recipe]":
-            varblock.append("            item_list: List[str] = []")
             varblock.append("            for item in tokenless_keys['{name}']:")
             varblock.append("                recipe = Recipe()")
             varblock.append("                errors += recipe.parse(item)")
             varblock.append("                self.{name}.append(recipe)")
-            # varblock.append("            self.{name}[str(key.value)] = item_list")
 
         else:
             print("UNKNOWN VARIABLE TYPE", variable.type, file=sys.stderr)
@@ -104,19 +106,20 @@ def generate_class(classname: str, variables: List[Variable]) -> None:
         print("\n".join(varblock).format(name=variable.name))
 
     print("        return errors")
-
+    print()
     print("    def to_primitive(self) -> Any:")
     print("        return {")
     for variable in variables:
         print("            \"{name}\": get_primitive(self.{name}),".format(name=variable.name))
     print("        }")
 
+
 def subobject_parse(object_name: str) -> List[str]:
     chunk = []
-    chunk.append("                "+object_name+"_subobject = "+object_name+"()")
-    chunk.append("                errors += "+object_name+"_subobject.parse(value)")
+    chunk.append("                " + object_name + "_subobject = " + object_name + "()")
+    chunk.append("                errors += " + object_name + "_subobject.parse(value)")
     chunk.append("")
-    chunk.append("                self.{name}[str(key.value)] = "+object_name+"_subobject")
+    chunk.append("                self.{name}[str(key.value)] = " + object_name + "_subobject")
     return chunk
 
 
@@ -195,7 +198,9 @@ generate_class(
             type="Optional[str]",
             default="None"
         ),
-        Variable( # This is actually a piece of data that is filled in via Resource.custom_stack_multipliers but it lives here for lookup
+        # custom_multipliers is a piece of data that is filled in via
+        # Resource.custom_stack_multipliers, but it lives here for lookup
+        Variable(
             name="custom_multipliers",
             type="OrderedDict[str, int]",
             default="OrderedDict()",

--- a/scripts/resource_list_type_generator.py
+++ b/scripts/resource_list_type_generator.py
@@ -1,0 +1,247 @@
+import sys
+from typing import List
+
+class Variable():
+    def __init__(self,
+        name: str,
+        type: str, # This is incorrect but I dont know yet what it should be yet
+        default: str, # This is probably redunatnt
+        # required: bool = False,
+    ):
+        self.name = name
+        self.type = type
+        self.default = default
+
+
+def generate_class(classname: str, variables: List[Variable]) -> None:
+    print("# Class Generated with resource_list_type_generator.py")
+    print("class {}():".format(classname))
+    print("    def __init__(self) -> None:")
+
+    for variable in variables:
+        print("        self.{}: {} = {}".format(variable.name, variable.type, variable.default))
+
+    print("")
+    print("        self.valid_keys = {}".format(str([v.name for v in variables])))
+    print("")
+    print("    def parse(self, tuple_tree: Any) -> List[TokenError]:")
+    print("        errors: List[TokenError] = []")
+    print("")
+    print("        # Create error for invalid keys")
+    print("        for invalid_key in _get_invalid_keys(tuple_tree, self.valid_keys):")
+    print("            errors.append(TokenError(\"Found Invalid {name} key, valid {name} keys are {{}}\".format(str(self.valid_keys)), Token().from_yaml_scalar_node(invalid_key.token)))".format(name=classname))
+    print("")
+    print("        tokenless_keys = {k.value:v for k, v in tuple_tree.items()}")
+
+    for variable in variables:
+        varblock = []
+
+        varblock.append("")
+        varblock.append("        # Load {name} into a typed object")
+        varblock.append("        if '{}' in tokenless_keys:".format(variable.name))
+
+        if variable.type == "str":
+            varblock.append("            {name} = tokenless_keys[\"{name}\"]")
+            varblock.append("            if type({name}.value) != str:")
+            varblock.append("                errors.append(TokenError(\"{name} should be a string not a {{}}\".format(str(type({name}.value))), Token().from_yaml_scalar_node({name}.token)))  ")
+            varblock.append("")
+            varblock.append("            self.{name} = str({name}.value)")
+        elif variable.type == "Optional[str]":
+            varblock.append("            {name} = tokenless_keys[\"{name}\"]")
+            varblock.append("            if {name}.value is not None:")
+            varblock.append("                if type({name}.value) != str:")
+            varblock.append("                    errors.append(TokenError(\"{name} should be a string not a {{}}\".format(str(type({name}.value))), Token().from_yaml_scalar_node({name}.token)))")
+            varblock.append("")
+            varblock.append("                self.{name} = str({name}.value)")
+        elif variable.type.startswith("OrderedDict["):
+            varblock.append("            for key, value in tokenless_keys[\"{name}\"].items():")
+            varblock.append("                if type(key.value) != str:")
+            varblock.append("                    errors.append(TokenError(\"{name} key should be a string not a {{}}\".format(str(type(key.value))), Token().from_yaml_scalar_node(key.token)))")
+            varblock.append("")
+
+            if variable.type == "OrderedDict[str, str]":
+                varblock.append("                if type(value.value) != str:")
+                varblock.append("                    errors.append(TokenError(\"{name} value should be a string not a {{}}\".format(str(type(value.value))), Token().from_yaml_scalar_node(value.token)))")
+                varblock.append("")
+                varblock.append("                self.{name}[str(key.value)] = str(value.value)")
+            elif variable.type == "OrderedDict[str, int]":
+                varblock.append("                if type(value.value) != int:")
+                varblock.append("                    errors.append(TokenError(\"{name} value should be an int not a {{}}\".format(str(type(value.value))), Token().from_yaml_scalar_node(value.token)))")
+                varblock.append("")
+                varblock.append("                self.{name}[str(key.value)] = int(value.value)")
+            elif variable.type == "OrderedDict[str, StackSize]":
+                varblock += subobject_parse("StackSize");
+
+            elif variable.type == "OrderedDict[str, Resource]":
+                varblock += subobject_parse("Resource");
+
+            elif variable.type == "OrderedDict[str, List[str]]":
+                varblock.append("                item_list: List[str] = []")
+                varblock.append("                for item in value:")
+                varblock.append("                    if type(item.value) != str:")
+                varblock.append("                        errors.append(TokenError(\"{name} element should be a string not a {{}}\".format(str(type(item.value))), Token().from_yaml_scalar_node(item.token)))")
+                varblock.append("                    item_list.append(str(item.value))")
+                varblock.append("                self.{name}[str(key.value)] = item_list")
+            else:
+                print("UNKNOWN VARIABLE TYPE", variable.type, file=sys.stderr)
+        elif variable.type == "int":
+            varblock.append("            {name} = tokenless_keys[\"{name}\"]")
+            varblock.append("            if type({name}.value) != int:")
+            varblock.append("                errors.append(TokenError(\"{name} should be an int not a {{}}\".format(str(type({name}.value))), Token().from_yaml_scalar_node({name}.token)))")
+            varblock.append("")
+            varblock.append("            self.{name} = int({name}.value)")
+        elif variable.type == "List[Recipe]":
+            varblock.append("            item_list: List[str] = []")
+            varblock.append("            for item in tokenless_keys['{name}']:")
+            varblock.append("                recipe = Recipe()")
+            varblock.append("                errors += recipe.parse(item)")
+            varblock.append("                self.{name}.append(recipe)")
+            # varblock.append("            self.{name}[str(key.value)] = item_list")
+
+        else:
+            print("UNKNOWN VARIABLE TYPE", variable.type, file=sys.stderr)
+
+        print("\n".join(varblock).format(name=variable.name))
+
+    print("        return errors")
+
+    print("    def to_primitive(self) -> Any:")
+    print("        return {")
+    for variable in variables:
+        print("            \"{name}\": get_primitive(self.{name}),".format(name=variable.name))
+    print("        }")
+
+def subobject_parse(object_name: str) -> List[str]:
+    chunk = []
+    chunk.append("                "+object_name+"_subobject = "+object_name+"()")
+    chunk.append("                errors += "+object_name+"_subobject.parse(value)")
+    chunk.append("")
+    chunk.append("                self.{name}[str(key.value)] = "+object_name+"_subobject")
+    return chunk
+
+
+generate_class(
+    classname="ResourceList",
+    variables=[
+        Variable(
+            name="authors",
+            type="OrderedDict[str, str]",
+            default="OrderedDict()"
+        ),
+        Variable(
+            name="index_page_display_name",
+            type="str",
+            default='""'
+        ),
+        Variable(
+            name="recipe_types",
+            type="OrderedDict[str, str]",
+            default="OrderedDict()"
+        ),
+        Variable(
+            name="stack_sizes",
+            type="OrderedDict[str, StackSize]",
+            default="OrderedDict()"
+        ),
+        Variable(
+            name="default_stack_size",
+            type="str",
+            default='""'
+        ),
+        Variable(
+            name="resources",
+            type="OrderedDict[str, Resource]",
+            default="OrderedDict()"
+        ),
+        Variable(
+            name="game_version",
+            type="str",
+            default='""'
+        ),
+        Variable(
+            name="banner_message",
+            type="str",
+            default='""'
+        ),
+        Variable(
+            name="requirement_groups",
+            type="OrderedDict[str, List[str]]",
+            default="OrderedDict()"
+        ),
+        Variable(
+            name="row_group_count",
+            type="int",
+            default="1",
+        )
+    ]
+)
+
+
+generate_class(
+    classname="StackSize",
+    variables=[
+        Variable(
+            name="quantity_multiplier",
+            type="int",
+            default="0"
+        ),
+        Variable(
+            name="plural",
+            type="str",
+            default='""'
+        ),
+        Variable(
+            name="extends_from",
+            type="Optional[str]",
+            default="None"
+        ),
+        Variable( # This is actually a piece of data that is filled in via Resource.custom_stack_multipliers but it lives here for lookup
+            name="custom_multipliers",
+            type="OrderedDict[str, int]",
+            default="OrderedDict()",
+        )
+    ]
+)
+
+
+generate_class(
+    classname="Resource",
+    variables=[
+        Variable(
+            name="recipes",
+            type="List[Recipe]",
+            default="[]"
+        ),
+        Variable(
+            name="custom_stack_multipliers",
+            type="OrderedDict[str, int]",
+            default="OrderedDict()"
+        ),
+        Variable(
+            name="custom_simplename",
+            type="str",
+            default='""',
+        ),
+    ]
+)
+
+generate_class(
+    classname="Recipe",
+    variables=[
+        Variable(
+            name="output",
+            type="int",
+            default="0",
+        ),
+        Variable(
+            name="recipe_type",
+            type="str",
+            default='""'
+        ),
+        Variable(
+            name="requirements",
+            type="OrderedDict[str, int]",
+            default="OrderedDict()"
+        )
+    ]
+)

--- a/tests/good_fields.yaml
+++ b/tests/good_fields.yaml
@@ -1,0 +1,22 @@
+---
+authors:
+  TesterPerson: "testerperson@example.com"
+  BOT: "bot.example.com"
+
+index_page_display_name: "Test"
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+
+resources:
+  MyResource:
+    recipes:
+    - recipe_type: Raw Resource
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MySubResource: -1
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource

--- a/tests/invalid_raw_resource.yaml
+++ b/tests/invalid_raw_resource.yaml
@@ -1,0 +1,23 @@
+---
+authors:
+  TesterPerson: "testerperson@example.com"
+  BOT: "bot.example.com"
+
+index_page_display_name: "Test"
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+
+resources:
+  MyResource:
+    recipes:
+    - output: 1
+      recipe_type: Raw Resource
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MySubResource: -1
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource

--- a/tests/invalid_recipe_type.yaml
+++ b/tests/invalid_recipe_type.yaml
@@ -1,0 +1,26 @@
+---
+authors:
+  TesterPerson: "testerperson@example.com"
+  BOT: "bot.example.com"
+
+index_page_display_name: "Test"
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+
+resources:
+  MyResource:
+    recipes:
+    - recipe_type: Raw Resource
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MySubResource: -1
+    - output: 1
+      recipe_type: UnkonwnRecipeType
+      requirements:
+        MySubResource: -1
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource

--- a/tests/invalid_requirement_count.yaml
+++ b/tests/invalid_requirement_count.yaml
@@ -1,0 +1,22 @@
+---
+authors:
+  TesterPerson: "testerperson@example.com"
+  BOT: "bot.example.com"
+
+index_page_display_name: "Test"
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+
+resources:
+  MyResource:
+    recipes:
+    - recipe_type: Raw Resource
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MySubResource: 99
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource

--- a/tests/invalid_requirement_name.yaml
+++ b/tests/invalid_requirement_name.yaml
@@ -1,0 +1,22 @@
+---
+authors:
+  TesterPerson: "testerperson@example.com"
+  BOT: "bot.example.com"
+
+index_page_display_name: "Test"
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+
+resources:
+  MyResource:
+    recipes:
+    - recipe_type: Raw Resource
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MyMissingSubResource: -1
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource

--- a/tests/invalid_resource_list_key.yaml
+++ b/tests/invalid_resource_list_key.yaml
@@ -1,0 +1,24 @@
+---
+authors:
+  TesterPerson: "testerperson@example.com"
+  BOT: "bot.example.com"
+
+index_page_display_name: "Test"
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+
+some_invalid_key: "I am an invalid key"
+
+resources:
+  MyResource:
+    recipes:
+    - recipe_type: Raw Resource
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MySubResource: -1
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource

--- a/tests/missing_raw_resource.yaml
+++ b/tests/missing_raw_resource.yaml
@@ -1,0 +1,21 @@
+---
+authors:
+  TesterPerson: "testerperson@example.com"
+  BOT: "bot.example.com"
+
+index_page_display_name: "Test"
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+
+resources:
+  MyResource:
+    recipes:
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MySubResource: -1
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource

--- a/tests/non_string_authors.yaml
+++ b/tests/non_string_authors.yaml
@@ -1,0 +1,21 @@
+---
+authors:
+  -5: 123456
+
+index_page_display_name: "Test"
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+
+resources:
+  MyResource:
+    recipes:
+    - recipe_type: Raw Resource
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MySubResource: -1
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource

--- a/tests/non_string_index_display_name.yaml
+++ b/tests/non_string_index_display_name.yaml
@@ -1,0 +1,22 @@
+---
+authors:
+  TesterPerson: "testerperson@example.com"
+  BOT: "bot.example.com"
+
+index_page_display_name: -1
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+
+resources:
+  MyResource:
+    recipes:
+    - recipe_type: Raw Resource
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MySubResource: -1
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource

--- a/tests/non_string_recipe_types.yaml
+++ b/tests/non_string_recipe_types.yaml
@@ -1,0 +1,23 @@
+---
+authors:
+  TesterPerson: "testerperson@example.com"
+  BOT: "bot.example.com"
+
+index_page_display_name: "Test"
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+  -999: 12345
+
+resources:
+  MyResource:
+    recipes:
+    - recipe_type: Raw Resource
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MySubResource: -1
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource

--- a/tests/unused_recipe_type.yaml
+++ b/tests/unused_recipe_type.yaml
@@ -1,0 +1,23 @@
+---
+authors:
+  TesterPerson: "testerperson@example.com"
+  BOT: "bot.example.com"
+
+index_page_display_name: "Test"
+
+recipe_types:
+  Crafting: "Craft {IN_ITEMS} into {OUT_ITEM}"
+  UnusedRecipeType: "Dont use {IN_ITEMS} to not make {OUT_ITEM}"
+
+resources:
+  MyResource:
+    recipes:
+    - recipe_type: Raw Resource
+    - output: 1
+      recipe_type: Crafting
+      requirements:
+        MySubResource: -1
+
+  MySubResource:
+    recipes:
+      - recipe_type: Raw Resource


### PR DESCRIPTION
This change begins to bring type hints to the resource calculator build script. It succeeds in adding types to nearly everything, with only a few exceptions around data that is about to be turned into JSON code.

All of the typed datastructure parsing from yaml is done via generated code which is reused for nested types. Due to this bespoke parsing there are some cases where the location of an error in the yeaml file can be provided.

A future change may allow this error location to be propagated to any yaml linter error we check for but that is out of scope of what this PR attempts to accomplish.

In addition to typing, the beginnings of a series of unit tests have been added. Hopefully more get added over time but these were primarily put in place to confirm that the new linter code was able to catch some of the same errors.

A regression as a result of this PR is that key ordering in yaml files is no longer linted and build.py will accept incorrectly ordered yaml fields without complaint.