### PR TITLE
Features/42 litematica material list import plugin

### DIFF
--- a/build.py
+++ b/build.py
@@ -672,6 +672,8 @@ def create_calculator_page(
     # re-triggering generation on outdated files that were intentionally skipped
     touch_output_folder_files(calculator_folder)
 
+    publish_calculator_plugins(calculator_folder, source_folder)
+
     if len(errors) > 0:
         with open(resource_list_file, 'r', encoding="utf_8") as f:
             fulltext = f.read()
@@ -683,6 +685,14 @@ def create_calculator_page(
     end_time = time.time()
     print("  Generated in %.3f seconds" % (end_time - start_time))
 
+def publish_calculator_plugins(
+    calculator_folder: str,
+    source_folder: str
+)  -> None:
+    plugin_output_folder = os.path.join(calculator_folder, "plugins")
+    plugin_source_folder = os.path.join(source_folder, "plugins")
+    if os.path.exists(plugin_source_folder):
+        shutil.copytree(plugin_source_folder, plugin_output_folder) 
 
 # [{
 #         "name":

--- a/build.py
+++ b/build.py
@@ -27,6 +27,7 @@ FLAG_skip_index = False
 FLAG_skip_gz_compression = False
 FLAG_skip_image_compress = False
 FLAG_force_image = False
+FLAG_no_plugins = False
 
 
 ################################################################################
@@ -691,8 +692,19 @@ def publish_calculator_plugins(
 )  -> None:
     plugin_output_folder = os.path.join(calculator_folder, "plugins")
     plugin_source_folder = os.path.join(source_folder, "plugins")
-    if os.path.exists(plugin_source_folder):
-        shutil.copytree(plugin_source_folder, plugin_output_folder) 
+
+    if os.path.exists(plugin_source_folder) and not FLAG_no_plugins:
+        should_publish_plugins = True
+
+        if os.path.exists(plugin_output_folder):
+            newest_file = max(
+                os.path.getctime("build.py"),  # Check generator code modification
+                get_newest_modified_time(plugin_source_folder),  # Check source plugin modification
+            )
+            should_publish_plugins = newest_file > os.path.getctime(plugin_output_folder)
+
+        if should_publish_plugins:
+            shutil.copytree(plugin_source_folder, plugin_output_folder) 
 
 # [{
 #         "name":
@@ -869,6 +881,7 @@ def main() -> None:
     parser.add_argument('--no-gz', action='store_true', help="Speed up dev-builds by skipping gz text compression")
     parser.add_argument('--no-index', action='store_true', help="Speed up dev-builds by skipping building the index page")
     parser.add_argument('--no-image-compress', action='store_true', help="Speed up dev-builds by skipping the image compresson")
+    parser.add_argument('--no-plugins', action='store_true', help="Skip plugin publication to get only the plain calculators")
 
     parser.add_argument('--force-html', action='store_true', help="Force the html pages to be rebuilt even if they are newer then their source files")
     parser.add_argument('--force-image', action='store_true', help="Force images to be rebuilt even if they are newer then their source files")
@@ -878,6 +891,7 @@ def main() -> None:
     global FLAG_skip_gz_compression
     global FLAG_skip_image_compress
     global FLAG_force_image
+    global FLAG_no_plugins
 
     args = parser.parse_args()
     if (args.watch):
@@ -900,6 +914,9 @@ def main() -> None:
 
     if args.force_image:
         FLAG_force_image = True
+
+    if args.no_plugins or args.draft:
+        FLAG_no_plugins = True
 
     calculator_page_sublist = []
     if len(args.limit_files) >= 1:

--- a/resource_lists/minecraft/plugins/litematica/index.html
+++ b/resource_lists/minecraft/plugins/litematica/index.html
@@ -1,0 +1,44 @@
+<html>
+
+<head>
+    <script src="./litematica.js" type="text/javascript"></script>
+    <link type="text/css" rel="stylesheet" href="./litematica.css" />
+</head>
+
+<body>
+    <div class="left">
+        <label for="input">Input</label><br />
+        <textarea name="input" id="input" rows="20" wrap="off">
++----------------------+-------+---------+---------------------------------+
+| Material List for | schematic 'Tunnel Bore (Dble Line)' (3 of 3 regions) |
++----------------------+-------+---------+---------------------------------+
+| Item                 | Total | Missing |                       Available |
++----------------------+-------+---------+---------------------------------+
+| Honey Block          |    12 |      12 |                               0 |
+| Observer             |     9 |       9 |                               0 |
+| Ancient Debris       |     6 |       6 |                               0 |
+| Smooth Stone Slab    |     6 |       6 |                               0 |
+| Piston               |     5 |       5 |                               0 |
+| Slime Block          |     5 |       5 |                               0 |
+| Sticky Piston        |     4 |       4 |                               0 |
+| Smooth Stone         |     3 |       3 |                               0 |
+| Dead Brain Coral Fan |     2 |       2 |                               0 |
+| Detector Rail        |     2 |       2 |                               0 |
+| Glowstone            |     2 |       2 |                               0 |
+| Stone Brick Wall     |     2 |       2 |                               0 |
+| TNT                  |     2 |       2 |                               0 |
+| Birch Fence          |     1 |       1 |                               0 |
+| Note Block           |     1 |       1 |                               0 |
+| Target               |     1 |       1 |                               0 |
++----------------------+-------+---------+---------------------------------+
+| Item                 | Total | Missing |                       Available |
++----------------------+-------+---------+---------------------------------+
+</textarea><br />
+        <label for="loadInputFile">Load Input File</label><input name="loadInputFile" type="file" id="loadInputFile" />
+    </div>
+    <div class="right">Output<br />
+        <a id="output" />
+    </div>
+</body>
+
+</html>

--- a/resource_lists/minecraft/plugins/litematica/index.html
+++ b/resource_lists/minecraft/plugins/litematica/index.html
@@ -2,26 +2,31 @@
 
 <head>
     <script src="./litematica.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="../../../calculator.css">
     <link type="text/css" rel="stylesheet" href="./litematica.css" />
 </head>
 
 <body>
     <div class="left">
-        <label for="input">Input</label><br />
-        <textarea name="input" id="input" rows="20" wrap="off">
-            +------+-------+---------+-----------+
-            | Material List for schematic ###### |
-            +------+-------+---------+-----------+
-            | Item | Total | Missing | Available |
-            +------+-------+---------+-----------+
-            | Name | 1     | 1       | 0         |
-            +------+-------+---------+-----------+
-            | Item | Total | Missing | Available |
-            +------+-------+---------+-----------+
-        </textarea><br />
-        <label for="loadInputFile">Load Input File</label><input name="loadInputFile" type="file" id="loadInputFile" />
+        <p>
+            <label for="input" id="inputLabel">Input</label><br />
+            <textarea name="input" id="input" rows="20" wrap="off">
++------+-------+---------+-----------+
+| Material List for schematic ###### |
++------+-------+---------+-----------+
+| Item | Total | Missing | Available |
++------+-------+---------+-----------+
+| Name | 1     | 1       | 0         |
++------+-------+---------+-----------+
+| Item | Total | Missing | Available |
++------+-------+---------+-----------+
+            </textarea>
+        </p>
+        <p>
+            <input name="loadInputFile" type="file" id="loadInputFile" class="generate_button" />
+        </p>
     </div>
-    <div class="right">Output<br />
+    <div class="right"><span id="outputLabel">Output</span><br />
         <a id="output" />
     </div>
 </body>

--- a/resource_lists/minecraft/plugins/litematica/index.html
+++ b/resource_lists/minecraft/plugins/litematica/index.html
@@ -9,16 +9,16 @@
     <div class="left">
         <label for="input">Input</label><br />
         <textarea name="input" id="input" rows="20" wrap="off">
-+------+-------+---------+-----------+
-| Material List for schematic ###### |
-+------+-------+---------+-----------+
-| Item | Total | Missing | Available |
-+------+-------+---------+-----------+
-| Item | 1     | 1       | 0         |
-+------+-------+---------+-----------+
-| Item | Total | Missing | Available |
-+------+-------+---------+-----------+
-</textarea><br />
+            +------+-------+---------+-----------+
+            | Material List for schematic ###### |
+            +------+-------+---------+-----------+
+            | Item | Total | Missing | Available |
+            +------+-------+---------+-----------+
+            | Name | 1     | 1       | 0         |
+            +------+-------+---------+-----------+
+            | Item | Total | Missing | Available |
+            +------+-------+---------+-----------+
+        </textarea><br />
         <label for="loadInputFile">Load Input File</label><input name="loadInputFile" type="file" id="loadInputFile" />
     </div>
     <div class="right">Output<br />

--- a/resource_lists/minecraft/plugins/litematica/index.html
+++ b/resource_lists/minecraft/plugins/litematica/index.html
@@ -7,10 +7,12 @@
 </head>
 
 <body>
+    <div class="top">
+        <h1>Litematica Material List Import</h1>
+    </div>
     <div class="left">
-        <p>
-            <label for="input" id="inputLabel">Input</label><br />
-            <textarea name="input" id="input" rows="20" wrap="off">
+        <label for="input" id="inputLabel">Input</label>
+        <textarea name="input" id="input" rows="20" wrap="off">
 +------+-------+---------+-----------+
 | Material List for schematic ###### |
 +------+-------+---------+-----------+
@@ -21,13 +23,11 @@
 | Item | Total | Missing | Available |
 +------+-------+---------+-----------+
             </textarea>
-        </p>
-        <p>
-            <input name="loadInputFile" type="file" id="loadInputFile" class="generate_button" />
-        </p>
+        <input name="loadInputFile" type="file" id="loadInputFile" class="generate_button" />
     </div>
-    <div class="right"><span id="outputLabel">Output</span><br />
-        <a id="output" />
+    <div class="right">
+        <span id="outputLabel">Output</span>
+        <a id="output"></a>
     </div>
 </body>
 

--- a/resource_lists/minecraft/plugins/litematica/index.html
+++ b/resource_lists/minecraft/plugins/litematica/index.html
@@ -9,30 +9,15 @@
     <div class="left">
         <label for="input">Input</label><br />
         <textarea name="input" id="input" rows="20" wrap="off">
-+----------------------+-------+---------+---------------------------------+
-| Material List for | schematic 'Tunnel Bore (Dble Line)' (3 of 3 regions) |
-+----------------------+-------+---------+---------------------------------+
-| Item                 | Total | Missing |                       Available |
-+----------------------+-------+---------+---------------------------------+
-| Honey Block          |    12 |      12 |                               0 |
-| Observer             |     9 |       9 |                               0 |
-| Ancient Debris       |     6 |       6 |                               0 |
-| Smooth Stone Slab    |     6 |       6 |                               0 |
-| Piston               |     5 |       5 |                               0 |
-| Slime Block          |     5 |       5 |                               0 |
-| Sticky Piston        |     4 |       4 |                               0 |
-| Smooth Stone         |     3 |       3 |                               0 |
-| Dead Brain Coral Fan |     2 |       2 |                               0 |
-| Detector Rail        |     2 |       2 |                               0 |
-| Glowstone            |     2 |       2 |                               0 |
-| Stone Brick Wall     |     2 |       2 |                               0 |
-| TNT                  |     2 |       2 |                               0 |
-| Birch Fence          |     1 |       1 |                               0 |
-| Note Block           |     1 |       1 |                               0 |
-| Target               |     1 |       1 |                               0 |
-+----------------------+-------+---------+---------------------------------+
-| Item                 | Total | Missing |                       Available |
-+----------------------+-------+---------+---------------------------------+
++------+-------+---------+-----------+
+| Material List for schematic ###### |
++------+-------+---------+-----------+
+| Item | Total | Missing | Available |
++------+-------+---------+-----------+
+| Item | 1     | 1       | 0         |
++------+-------+---------+-----------+
+| Item | Total | Missing | Available |
++------+-------+---------+-----------+
 </textarea><br />
         <label for="loadInputFile">Load Input File</label><input name="loadInputFile" type="file" id="loadInputFile" />
     </div>

--- a/resource_lists/minecraft/plugins/litematica/litematica.css
+++ b/resource_lists/minecraft/plugins/litematica/litematica.css
@@ -1,0 +1,21 @@
+.left {
+    display: inline-block;
+    width: 45%;
+    padding-right: 15px;
+}
+
+.right {
+    display: inline-block;
+    width: 45%;
+    word-break: break-word;
+    text-align: right;
+    vertical-align: top;
+    padding-left: 5px;
+}
+
+#input {
+    font-family: monospace;
+    white-space: pre;
+    overflow-x: auto;
+    width: 100%;
+}

--- a/resource_lists/minecraft/plugins/litematica/litematica.css
+++ b/resource_lists/minecraft/plugins/litematica/litematica.css
@@ -1,3 +1,15 @@
+.top {
+    display: block;
+    width: 100%;
+    text-align: center;
+}
+
+h1 {
+    font-weight: bold;
+    font-size: 1.3em;
+    margin-top: 1em;
+}
+
 .left {
     display: inline-block;
     width: 45%;
@@ -12,21 +24,28 @@
     text-align: right;
     vertical-align: top;
     padding-left: 10px;
-    margin-right: calc(5% - 10);
+    margin-right: calc(3% - 10px);
 }
 
 #input,
 #output {
     font-family: monospace;
-    white-space: pre;
     overflow-x: auto;
-    width: 100%;
     padding: 5px 10px;
     border: 2px solid #8b90a1;
     border-top: 0;
     background: #FFF;
     border-radius: 0 0 5px 5px;
-    display: inline-block;
+    display: block;
+}
+
+#input {
+    width: 100%;
+    white-space: pre;
+}
+
+#output {
+    white-space: normal;
 }
 
 #inputLabel,
@@ -37,5 +56,10 @@
     background: #D8D9ED;
     border-radius: 5px 5px 0 0;
     width: calc(100% - 24px);
-    display: inline-block;
+    display: block;
+}
+
+#loadInputFile {
+    margin-top: 15px;
+    width: 100%;
 }

--- a/resource_lists/minecraft/plugins/litematica/litematica.css
+++ b/resource_lists/minecraft/plugins/litematica/litematica.css
@@ -1,7 +1,8 @@
 .left {
     display: inline-block;
     width: 45%;
-    padding-right: 15px;
+    padding-right: 10;
+    margin-left: calc(5% - 10px);
 }
 
 .right {
@@ -10,12 +11,31 @@
     word-break: break-word;
     text-align: right;
     vertical-align: top;
-    padding-left: 5px;
+    padding-left: 10px;
+    margin-right: calc(5% - 10);
 }
 
-#input {
+#input,
+#output {
     font-family: monospace;
     white-space: pre;
     overflow-x: auto;
     width: 100%;
+    padding: 5px 10px;
+    border: 2px solid #8b90a1;
+    border-top: 0;
+    background: #FFF;
+    border-radius: 0 0 5px 5px;
+    display: inline-block;
+}
+
+#inputLabel,
+#outputLabel {
+    padding: 5px 10px 10px;
+    border: 2px solid #8b90a1;
+    border-bottom: 0;
+    background: #D8D9ED;
+    border-radius: 5px 5px 0 0;
+    width: calc(100% - 24px);
+    display: inline-block;
 }

--- a/resource_lists/minecraft/plugins/litematica/litematica.js
+++ b/resource_lists/minecraft/plugins/litematica/litematica.js
@@ -6,18 +6,18 @@ function convertMaterialListToRequestHash(inputString) {
         // remove trailing spaces
         .replace(/\s+(\n|$)/gm, "$1")
         // remove illegal characters (see build.py get_simple_name function)
-        .toLowerCase().replaceAll(/[^a-z0-9|\n]/gm, "")
+        .toLowerCase().replaceAll(/[^a-z0-9|,\n]/gm, "")
         // remove non-item lines
-        .replace(/(\n|^)(?!\|(\S+)\|(\d+)\|(\d+)\|(\d+)\|)(.*?)(\n|$)/gm, "")
+        .replace(/(\n|^)(?!\|(\S+)\|(\d+)\|(\d+)\|(\d+)\||[a-z0-9]+,\d+,\d+,\d+)(.*?)(\n|$)/gm, "")
         // convert into csv
-        .replace(/(\n|^)\|(.+?)\|(\d+)\|(\d+)\|(\d+)\|(\n|$)/gm, "$1$2;$3;$4;$5$6")
+        .replace(/(\n|^)\|(.+?)\|(\d+)\|(\d+)\|(\d+)\|(\n|$)/gm, "$1$2,$3,$4,$5$6")
         // remove leading & trailing blank lines
         .trim();
 
     // convert each line into a "name=##"-format with the totals as value
     var items = inputString.split("\n");
     var totals = items.map((item) => {
-        var itemTotal = item.split(";");
+        var itemTotal = item.split(",");
         return [itemTotal[0], itemTotal[1]].join("=");
     });
 
@@ -41,7 +41,7 @@ document.addEventListener("DOMContentLoaded", function() {
     document.getElementById("loadInputFile").addEventListener('change', function() {
         var file = document.getElementById("loadInputFile").files[0];
 
-        if (file.name.match(/\.(txt)$/)) {
+        if (file.name.match(/\.(txt|csv)$/)) {
             var reader = new FileReader();
 
             reader.onload = function() {
@@ -51,7 +51,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
             reader.readAsText(file);
         } else {
-            alert("File not supported, .txt files only");
+            alert("File not supported, .txt or .csv files only");
         }
     });
 

--- a/resource_lists/minecraft/plugins/litematica/litematica.js
+++ b/resource_lists/minecraft/plugins/litematica/litematica.js
@@ -1,0 +1,60 @@
+function convertMaterialListToRequestHash(inputString) {
+    // unify line endings
+    inputString = inputString.replace(/\r\n/gm, "\n")
+        // remove preface lines
+        .replace(/^(.*\n){5}/, "")
+        // remove delimiter lines
+        .replace(/(\r?\n|^)\+-+\+-+\+-+\+-+\+(\r?\n|$)/gm, "$1")
+        // remove all lines without numbers between the pipes (aka headlines)
+        .replace(/(\r?\n|^)\|[^0-9]+\|(\r?\n|$)/gm, "$1")
+        // convert into csv
+        .replace(/\| +(.+?) +\| +(\d+) +\| +(\d+) +\| +(\d+) +\|/gm, "$1;$2;$3;$4")
+        // remove leading & trailing blank lines
+        .trim();
+
+    // convert each line into a "name=##"-format with the totals as value
+    var items = inputString.split("\n");
+    var totals = items.map((item) => {
+        var itemTotal = item.split(";");
+        return [itemTotal[0].trim().toLowerCase().replaceAll(/[^a-z0-9]/gm, ""), itemTotal[1]].join("=");
+    });
+
+    var totalsQuery = "#" + totals.join("&");
+    return totalsQuery;
+}
+
+function setOutput(outputString) {
+    var outputElement = document.getElementById("output");
+    outputElement.innerText = outputString;
+    outputElement.href = "../../" + outputString;
+}
+
+function processInput() {
+    var inputString = document.getElementById("input").value;
+    var outputString = convertMaterialListToRequestHash(inputString);
+    setOutput(outputString);
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+    document.getElementById("loadInputFile").addEventListener('change', function() {
+        var file = document.getElementById("loadInputFile").files[0];
+
+        if (file.name.match(/\.(txt)$/)) {
+            var reader = new FileReader();
+
+            reader.onload = function() {
+                document.getElementById("input").value = reader.result;
+                processInput();
+            };
+
+            reader.readAsText(file);
+        } else {
+            alert("File not supported, .txt files only");
+        }
+    });
+
+    document.getElementById("input").addEventListener('change', processInput);
+    document.getElementById("input").addEventListener('keyup', processInput);
+
+    processInput();
+});

--- a/resource_lists/minecraft/plugins/litematica/litematica.js
+++ b/resource_lists/minecraft/plugins/litematica/litematica.js
@@ -1,14 +1,16 @@
 function convertMaterialListToRequestHash(inputString) {
     // unify line endings
     inputString = inputString.replace(/\r\n/gm, "\n")
-        // remove preface lines
-        .replace(/^(.*\n){5}/, "")
-        // remove delimiter lines
-        .replace(/(\r?\n|^)\+-+\+-+\+-+\+-+\+(\r?\n|$)/gm, "$1")
-        // remove all lines without numbers between the pipes (aka headlines)
-        .replace(/(\r?\n|^)\|[^0-9]+\|(\r?\n|$)/gm, "$1")
+        // remove leading spaces
+        .replace(/(\n|^)\s+/gm, "$1")
+        // remove trailing spaces
+        .replace(/\s+(\n|$)/gm, "$1")
+        // remove illegal characters (see build.py get_simple_name function)
+        .toLowerCase().replaceAll(/[^a-z0-9|\n]/gm, "")
+        // remove non-item lines
+        .replace(/(\n|^)(?!\|(\S+)\|(\d+)\|(\d+)\|(\d+)\|)(.*?)(\n|$)/gm, "")
         // convert into csv
-        .replace(/\| +(.+?) +\| +(\d+) +\| +(\d+) +\| +(\d+) +\|/gm, "$1;$2;$3;$4")
+        .replace(/(\n|^)\|(.+?)\|(\d+)\|(\d+)\|(\d+)\|(\n|$)/gm, "$1$2;$3;$4;$5$6")
         // remove leading & trailing blank lines
         .trim();
 
@@ -16,7 +18,7 @@ function convertMaterialListToRequestHash(inputString) {
     var items = inputString.split("\n");
     var totals = items.map((item) => {
         var itemTotal = item.split(";");
-        return [itemTotal[0].trim().toLowerCase().replaceAll(/[^a-z0-9]/gm, ""), itemTotal[1]].join("=");
+        return [itemTotal[0], itemTotal[1]].join("=");
     });
 
     var totalsQuery = "#" + totals.join("&");


### PR DESCRIPTION
This implements #42 by adding a plugin publishing routine to the build.py, that looks for a `plugins`-directory in each calculator's directory within `resource_lists`. This will be copied in full to the output directory.

For the time being I do not implement minification, as I don't expect the plugins to be large chunks of code, but rather to be small snippets.

The implemented plugin for the minecraft calculator allows to either load a material list as a file or copy its content to a textarea and generate a link to the calculator with all the items from the list picked with the respective amounts.
The material lists are expected to be in the format of the material lists, created by the Minecraft Mod [litematica](https://github.com/maruohon/litematica).