### PR TITLE
Fix two issues regarding Minecraft concrete

### DIFF
--- a/resource_lists/minecraft/resources.yaml
+++ b/resource_lists/minecraft/resources.yaml
@@ -4580,7 +4580,7 @@ resources:
 
   Black Concrete:
     recipes:
-    - output: 8
+    - output: 1
       recipe_type: Add Water
       requirements:
         Black Concrete Powder: -1
@@ -4673,6 +4673,7 @@ resources:
       requirements:
         Sand: -4
         Gravel: -4
+        Light Gray Dye: -1
     - recipe_type: Raw Resource
 
   Cyan Concrete Powder:


### PR DESCRIPTION
This fixes two issues regarding Minecraft concrete:

1. Pouring water on black concrete powder should give 1 black concrete, not 8.
2. Crafting light gray concrete powder should require light gray dye.