### PR TITLE
Tracking when files are copied/moved not just updated

### DIFF
--- a/pylib/producer/scheduler.py
+++ b/pylib/producer/scheduler.py
@@ -856,7 +856,7 @@ def get_aggregated_modified_time(
             for subpath in os.listdir(path):
                 paths.append(os.path.join(path, subpath))
         else:
-            time_list.append(os.path.getmtime(path))
+            time_list.append(max(os.path.getmtime(path), os.path.getctime(path)))
 
     # Sanity check that there are timestamps in the list before passing them
     # to the aggregator.


### PR DESCRIPTION
If a file is moved into a folder then the current cache invalidation detection wont see it if its modified time is not updated as well. This adds a check on mtime (modified) as well as ctime (change) to see if either of these values are newer then the current cached files.