### PR TITLE
Moves reset button out of navigation bar

### DIFF
--- a/core/calculator.css
+++ b/core/calculator.css
@@ -70,58 +70,67 @@ body {
 
 .search_bar {
 	margin-bottom: 10px;
-
-}
-
-.search_label_wrapper {
-	float:left;
-	padding: 5px 10px;
 	border: 2px solid #8b90a1;
-	border-right: 0;
-	background: #D8D9ED;
-	border-radius: 5px 0 0 5px;
-}
-.search_label {
+	border-radius: 5px;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
 }
 
 .search_box_wrapper {
-	display: block;
 	overflow: hidden;
+	flex-grow: 1;
 }
 .search_box {
 	width: 100%;
-	box-sizing:border-box;
+	box-sizing: border-box;
 	padding: 5px;
 	margin: 0;
 	color: #000;
 	font-family: sans-serif;
 	background-color: #fff;
 	border: none;
-	border-top: 2px solid #8b90a1;
-	border-bottom: 2px solid #8b90a1;
 	font-size: 1em;
 }
 
-
-
-
-.hide_unused_wrapper {
-	float:right;
-	padding: 5px 10px;
-	border: 2px solid #8b90a1;
-	border-radius: 0 5px 5px 0;
+.search_bar_button {
+	padding: 5px 9px;
+	border: none;
+	border-left: 2px solid #8b90a1;
+	outline: none;
 	background: #FFF;
 	transition: background-color 0.1s linear, color 0.1s linear;
+	font-size: inherit;
+	cursor: pointer;
+}
+
+#search_label_wrapper {
+	background: #D8D9ED;
+	border: none;
+	border-right: 2px solid #8b90a1;
+	cursor: none;
+}
+@media (max-width:768px) {
+	#search_label_wrapper {
+		display: none;
+	}
+}
+.hide_unused_wrapper {
+	display: inline-block;
 }
 .hide_unused_wrapper:hover {
 	background: #D8D9ED;
 }
-
 .hide_unused_label {
-	cursor: pointer;
+	cursor: inherit;
 }
-
-
+#reset_item_count {
+	display: inline-block;
+	background-color: #ffbcbc
+}
+#reset_item_count:hover {
+	background-color: #ff8282
+}
 
 
 #item_list {

--- a/core/calculator.html
+++ b/core/calculator.html
@@ -30,7 +30,6 @@
 	<body>
 		<div class="header_bar">
 			<a href="/" aria-label="Home"><div class="home_button_logo">&nbsp;</div></a>
-			<a href="#" id="reset_item_count"><div class="home_button"> Reset Item Counts</div></a>
 			<a href="mailto:admin@resourcecalculator.com?Subject=Resource%20Calculator%20Issue"><div class="home_button">Report An Issue</div></a>
 			<a href="https://github.com/AsherGlick/ResourceCalculator/blob/master/README.md"><div class="home_button">Contribute</div></a>
 			<a><div id="about_button" class="home_button">About</div></a>
@@ -57,16 +56,19 @@
 				</div>
 				<!-- <input type="button" class="inventory_import_export_toggle" title="Show/Hide Inventory as Text" value="Show/Hide Inventory as Text"/> -->
 				<div class="search_bar">
-					<div class='hide_unused_wrapper'>
-						<input type="checkbox" id="unused_hide_checkbox" class="hide_unused_checkbox" />
-						<label class="hide_unused_label" for="unused_hide_checkbox" id="unused_hide_checkbox_label">Hide Unused</label>
-					</div>
-					<div class="search_label_wrapper">
+					<div id="search_label_wrapper" class="search_bar_button">
 						<label class="search_label" for="item_filter">Filter:</label>
 					</div>
-					<span class="search_box_wrapper">
-						<input type="text" class="search_box" id="item_filter" />
-					</span>
+					<div class="search_box_wrapper">
+						<input type="text" id="item_filter" class="search_box" placeholder="Type to filter items..." />
+					</div>
+					<div>
+						<div class="hide_unused_wrapper search_bar_button">
+							<input type="checkbox" id="unused_hide_checkbox" class="hide_unused_checkbox" />
+							<label class="hide_unused_label" for="unused_hide_checkbox" id="unused_hide_checkbox_label">Hide Unused</label>
+						</div>
+						<button type="button" id="reset_item_count" class="search_bar_button">Reset</button>
+					</div>
 				</div>
 
 				<div class="resource_content">

--- a/core/src/calculator.ts
+++ b/core/src/calculator.ts
@@ -30,8 +30,12 @@ const inventory_amount_input_elem = <HTMLInputElement>document.getElementById("i
 | "Reset Item Counts" Button Logic                                             |
 \******************************************************************************/
 function clear_item_counts() {
+	if (!confirm("Are you sure you want to clear all items?")) {
+		return;
+	}
+
 	document.querySelectorAll(".desired_item").forEach((desired_item) => {
-		let field = <HTMLInputElement>desired_item.querySelector(".desired_item_count");
+		const field = <HTMLInputElement>desired_item.querySelector(".desired_item_count");
 		field.value = "";
 		set_textbox_background(field);
 	});


### PR DESCRIPTION
Moves "Reset Item Counts" out of the navbar and into a more contextually relevant place. Reset button is red and pops a confirm dialog before carrying out the reset.

To conserve space on mobile this also hides the `Filter:` label once the screen is smaller, and placeholder text has been added to explain the function in lieu of this.

Longer-term it would make sense to either explore swapping to icons on mobile or having the two buttons occupy a second row, but that can be revisited as a part of mobile-supporting work.

Before:
![image](https://github.com/user-attachments/assets/3bf6223c-b3d1-4941-94eb-0323f2f14f95)

After:
![image](https://github.com/user-attachments/assets/d3921abb-a073-4143-8d3a-b4ddfd4298d6)
![image](https://github.com/user-attachments/assets/b9afd0f4-a004-45db-9234-f306a476c128)
![image](https://github.com/user-attachments/assets/e48d0b9a-d58f-4d2c-993c-e1eefac45356)
