### PR TITLE
Adding cachebusting to calculator.js

### DIFF
--- a/build.py
+++ b/build.py
@@ -41,6 +41,7 @@ def core_resource_producers() -> List[GenericProducer]:
     hashed_copyfiles = [
         "core/calculator.css",
         "core/add_game.png",
+        "cache/calculator.min.js",
     ]
 
     # Files that should be copied out of the "core" folder.
@@ -61,10 +62,10 @@ def core_resource_producers() -> List[GenericProducer]:
     }
 
     # Javascript files that should be minified for production.
-    minify_js_files = [
-        "cache/calculator.js",
-        "core/yaml_export.js",
-    ]
+    minify_js_files = {
+        "cache/calculator.js": "cache/calculator.min.js",
+        "core/yaml_export.js": "output/yaml_export.js",
+    }
 
     core_producers: List[GenericProducer] = []
 
@@ -98,10 +99,7 @@ def core_resource_producers() -> List[GenericProducer]:
         core_producers += js_rollup_producer(js_target_file, js_destination_file)
 
     # Add a producer for each javascript file to minify.
-    for minify_js_file in minify_js_files:
-        input_file = minify_js_file
-        output_file = os.path.join("output", os.path.basename(minify_js_file))
-
+    for input_file, output_file in minify_js_files.items():
         if FLAG_skip_js_minify:
             core_producers.append(copy_file(
                 name=f"Copy File {input_file}",

--- a/core/calculator.html
+++ b/core/calculator.html
@@ -174,6 +174,6 @@
 		<script>{{ recipe_json }}</script>
 		<script>{{ recipe_type_format_js }}</script>
 		<script>var stack_sizes = {{ stack_sizes_json }};</script>
-		<script src = "../calculator.js" type = "text/javascript"/></script>
+		<script src = "{{calculator_js_path}}" type = "text/javascript"/></script>
 	</body>
 </html>

--- a/pylib/calculator_producer.py
+++ b/pylib/calculator_producer.py
@@ -35,6 +35,7 @@ def calculator_producers(calculator_dir_regex: str) -> List[GenericProducer]:
             "css_filename_data": r"^cache/calculator\.css\.json",
             "calculator_template": r"^core/calculator\.html$",
             "recipe_type_display_function_template": r"^core/_recipe_type_display_functions\.js$",
+            "calculator_js_metadata": r"^cache/calculator\.min\.js\.json$"
         },
         function=calculator_function,
     )
@@ -56,6 +57,7 @@ class CalculatorInputFiles(TypedDict):
     css_filename_data: str
     calculator_template: str
     recipe_type_display_function_template: str
+    calculator_js_metadata: str
 
 
 ################################################################################
@@ -80,6 +82,9 @@ def calculator_function(input_files: CalculatorInputFiles, groups: Dict[str, str
 
     # Get the relative hashed name of the calculator's stitched item images
     calculator_item_image = filename_from_metadatafile(input_files["image_metadata"], rel=os.path.dirname(calculator_index_html_filepath))
+
+    # Get the calculator js path
+    calculator_js_path = filename_from_metadatafile(input_files["calculator_js_metadata"], rel=os.path.dirname(calculator_index_html_filepath))
 
     # Load and validate the type of the resource list data
     with open(resource_list_file, 'rb') as f:
@@ -142,6 +147,8 @@ def calculator_function(input_files: CalculatorInputFiles, groups: Dict[str, str
         # Used to do calculations to divide counts into stacks
         stack_sizes_json=stack_sizes_json,
         css_path=css_path,
+        # CalculatorJS Path
+        calculator_js_path=calculator_js_path,
     )
 
     minified_calculator = htmlmin.minify(rendered_calculator, remove_comments=True, remove_empty_space=True)


### PR DESCRIPTION
`calculator.js` does not change as often as other files but it can still be effected by outdated caching. This adds a cachebusting hash to it which should fix any issues with it being cached after it is changed.