### PR TITLE
Fixes VB recipe

### DIFF
--- a/resource_lists/void_bastards/resources.yaml
+++ b/resource_lists/void_bastards/resources.yaml
@@ -479,7 +479,7 @@ resources:
       - output: 1
         recipe_type: Build
         requirements:
-          V.P. Gunpoints: 1
+          Robo Manual: 1
           WCG Policy: 1
           Gunpoint MGR: 1
   - name: Merit Badge


### PR DESCRIPTION
Broader circular dependency identification is likely difficult, but a linter check to see if an item has a recipe that includes itself might be a good check for copy/paste errors like this.