### PR TITLE
Info pane support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ that resource. If an image is missing, then the build process will submit a
 warning and fill that space with a purple color, indicating it does not have
 an icon.
 
-The icons can be any size, even rectangular, but they all must be the same size
+The icons can be any size, not necessarily square, but they all must be the same size
 as each other for a given calculator.
 The file names of each file should be the resource name in all lower case with
 no spaces or punctuation.
@@ -159,8 +159,8 @@ python3 build.py --watch
 
 Docker
 --------------------------------------------------------------------------------
-The secondary method for building resource calculator is using Docker and Docker
-Compose. As long as you have Docker Compose on your system you should be able
+The secondary method for building resource calculator is using [Docker](https://www.docker.com/) and [Docker
+Compose](https://docs.docker.com/compose/). As long as you have Docker Compose on your system you should be able
 to run the `./run.sh` command from any terminal that can run a shell script.
 This will start two docker containers, one which will build the calculator and
 one which will host the calculator output so you can easily access it via a web
@@ -180,9 +180,9 @@ The docker container will install the node and python libraries into the
 
 Windows
 --------------------------------------------------------------------------------
-On windows it is recommended to use the Docker runtime. However if you do not
+On Windows it is recommended to use the Docker runtime. However if you do not
 wish to use it you can install the dependencies manually using native versions,
-cygwin, or wsl just like on Linux.
+[cygwin](https://www.cygwin.com/), or [wsl](https://github.com/microsoft/WSL) just like on Linux.
 
 > [!IMPORTANT]
 > For Docker on Windows you may need to allow the docker container to access

--- a/build_test.py
+++ b/build_test.py
@@ -63,7 +63,7 @@ class Test_Invalid_Yaml(unittest.TestCase):
         errors = test_load("tests/invalid_resource_list_key.yaml")
         desired_errors: List[TokenError] = [
             TokenError(
-                "Found Invalid ResourceList key, valid ResourceList keys are ['authors', 'index_page_display_name', 'game_version', 'row_group_count', 'note', 'banner_message', 'recipe_types', 'requirement_groups', 'stack_sizes', 'default_stack_size', 'resources']",
+                "Found Invalid ResourceList key, valid ResourceList keys are ['authors', 'calculator_display_name', 'game_version', 'row_group_count', 'note', 'banner_message', 'recipe_types', 'requirement_groups', 'stack_sizes', 'default_stack_size', 'resources']",
                 Token(10, 10, 0, 16)
             )
         ]
@@ -87,7 +87,7 @@ class Test_Invalid_Yaml(unittest.TestCase):
     def test_non_string_index_display_name(self) -> None:
         errors = test_load("tests/non_string_index_display_name.yaml")
         desired_errors: List[TokenError] = [
-            TokenError("index_page_display_name should be a string not a <class 'int'>", Token(5, 5, 25, 27))
+            TokenError("calculator_display_name should be a string not a <class 'int'>", Token(5, 5, 25, 27))
         ]
         self.assertListEqual(errors, desired_errors)
 

--- a/core/calculator.css
+++ b/core/calculator.css
@@ -10,6 +10,58 @@ body {
 	overflow-x: hidden;
 }
 
+#title_container {
+	margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 10px;
+	text-align: center;
+}
+.title {
+	font-size: larger;
+	anchor-name: --calc_info_anchor;
+}
+.info_button {
+	border: none;
+  	cursor: pointer;
+}
+.info_popover[popover] {
+	position: absolute;
+	max-width: 320px;
+	border: none;
+	border-radius: 5px;
+	background: #FFF;
+	padding: 10px;
+	color: #000;
+	white-space: nowrap;
+	display: none;
+	opacity: 0;
+	z-index: 3;
+	box-shadow: 2px 2px 5px 0 #000;
+	transition: opacity .1s linear;
+
+	position: fixed;
+	position-anchor: --calc_info_anchor;
+	top: anchor(bottom);
+	margin-top: 8px;
+}
+.info_popover[popover]:popover-open {
+	opacity: 1;
+	display: block;
+}
+.info_popover ul {
+	width: fit-content;
+    margin: 0 auto;
+	padding-inline-start: 0;
+	list-style-position: inside;
+	text-align: left;
+}
+.info_popover a {
+  	color: black;
+}
+.info_popover a:hover {
+ 	text-decoration: underline;
+}
+
 .content {
 	margin-left: 8px;
 	margin-right: 8px;
@@ -70,7 +122,6 @@ body {
 
 .search_bar {
 	margin-bottom: 10px;
-
 }
 
 .search_label_wrapper {
@@ -80,8 +131,6 @@ body {
 	border-right: 0;
 	background: #D8D9ED;
 	border-radius: 5px 0 0 5px;
-}
-.search_label {
 }
 
 .search_box_wrapper {
@@ -144,13 +193,6 @@ body {
 
 }
 
-
-#generatelist {
-
-}
-
-
-
 .hide_unused_checkbox {
 	display: none;
 }
@@ -158,7 +200,7 @@ body {
 
 
 #hover_name {
-	position:absolute;
+	position: absolute;
 	border-radius: 5px;
 	background: #FFF;
 	padding: 10px;
@@ -293,7 +335,7 @@ body {
 
 .header_bar {
 	overflow: hidden;
-	margin-bottom: 40px;
+	margin-bottom: 20px;
 	text-align: center;
 }
 
@@ -565,7 +607,7 @@ body {
 }
 .icon img {
 	border: 2px solid black;
-		border-top: 2px solid #CBCBCB;
+	border-top: 2px solid #CBCBCB;
 	border-left: 2px solid #CBCBCB;
 	border-radius: 5px;
 	padding: 5px;

--- a/core/calculator.html
+++ b/core/calculator.html
@@ -44,16 +44,24 @@
 
 		<div id="title_container">
 			<span class="title">Resource Calculator - {{calculator_display_name}}</span>
+			{% if game_version != "" or authors | length > 0 %}
 			<button class="info_button"	popovertarget="calc_info">&#x1F6C8;</button>
 			<div id="calc_info" class="info_popover" popover="auto">
+				{% if game_version != "" %}
 			 	Up to date as of game version:<br>
 				"{{game_version}}"<br>
-				<br>
+				{% endif %}
+				{% if game_version != "" and authors | length > 0 %}<br>{% endif %}
+				{% if authors | length > 0 %}
 				This calculator was created/updated by:
-				<div id="author_list"><ul>{% for author in authors %}
-				<li><a {% if authors[author] != "" %}href="{% if '@' in authors[author] %}mailto:{% endif %}{{authors[author]}}"{% endif %} target="_blank">{{ author }}</a></li>
-				{% endfor %}</ul></div>
+				<ul>{% for author in authors %}
+				<li>{% if authors[author] != "" %}<a href="{% if '@' in authors[author] %}mailto:{% endif %}{{authors[author]}}" target="_blank">{% endif %}
+					{{ author }}
+				{% if authors[author] != "" %}</a>{% endif %}</li>
+				{% endfor %}</ul>
+				{% endif %}
 			</div>
+			{% endif %}
 		</div>
 
 		<div id="content" class="content">

--- a/core/calculator.html
+++ b/core/calculator.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>ResourceCalculator</title>
+		<title>Resource Calculator - {{calculator_display_name}}</title>
 
 		<link rel="stylesheet" href="{{css_path}}">
 		<meta charset="UTF-8">
@@ -39,14 +39,22 @@
 
 		<div id="about_us">
 			Resource Calculator is an open source project to allow players to easily calculate how many raw resources they need in order to construct the items they want.
-			It was originally created by Asher Glick. You can help keep Resource Calculator up to date or add resources for new games by clicking on the Contribute button above. <br><br> The resources and recipes for the <b>{{calculator_name}} calculator</b> were created and updated by<br>
-			{% for author in authors %}
-
-
-			- <a {% if authors[author] != "" %}href="{{authors[author]}}"{% endif %}>{{ author }}</a><br>
-			{% endfor %}
+			It was originally created by Asher Glick. You can help keep Resource Calculator up to date or add resources for new games by clicking on the Contribute button above.
 		</div>
 
+		<div id="title_container">
+			<span class="title">Resource Calculator - {{calculator_display_name}}</span>
+			<button class="info_button"	popovertarget="calc_info">&#x1F6C8;</button>
+			<div id="calc_info" class="info_popover" popover="auto">
+			 	Up to date as of game version:<br>
+				"{{game_version}}"<br>
+				<br>
+				This calculator was created/updated by:
+				<div id="author_list"><ul>{% for author in authors %}
+				<li><a {% if authors[author] != "" %}href="{% if '@' in authors[author] %}mailto:{% endif %}{{authors[author]}}"{% endif %} target="_blank">{{ author }}</a></li>
+				{% endfor %}</ul></div>
+			</div>
+		</div>
 
 		<div id="content" class="content">
 			<div id="content_field" class="menu_style">

--- a/core/yaml_export.js
+++ b/core/yaml_export.js
@@ -3,26 +3,42 @@ function write_ResourceList(object, indented=0){
     let output = "";
     const tab = "  ";
     let indent = tab.repeat(indented);
-    const key_list = ["authors","index_page_display_name","row_group_count","game_version","banner_message","recipe_types","requirement_groups","stack_sizes","default_stack_size","resources"];
+    const key_list = [
+      "authors",
+      "calculator_display_name",
+      "row_group_count",
+      "game_version",
+      "banner_message",
+      "recipe_types",
+      "requirement_groups",
+      "stack_sizes",
+      "default_stack_size",
+      "resources",
+    ];
     const key_set = new Set(key_list);
     let key_names = Object.keys(object);
     for (var i in key_names) {
-        let key_name = key_names[i];
-        if (!key_set.has(key_name)) {
-            console.warn("Unknown Key Found " + key_name);
-        }
+      let key_name = key_names[i];
+      if (!key_set.has(key_name)) {
+        console.warn("Unknown Key Found " + key_name);
+      }
     }
     if ("authors" in object) {
-        output += indent + "authors:"
-        output += "\n";
-        for (let list_index in object["authors"]) {
-        output += indent + tab + "- " + write_Author(object["authors"][list_index], indented+2).trim() + "\n";
-        }
+      output += indent + "authors:";
+      output += "\n";
+      for (let list_index in object["authors"]) {
+        output +=
+          indent +
+          tab +
+          "- " +
+          write_Author(object["authors"][list_index], indented + 2).trim() +
+          "\n";
+      }
     }
-    if ("index_page_display_name" in object) {
-        output += "\n"
-        output += indent + "index_page_display_name:"
-        output += " \"" + object["index_page_display_name"] + "\"\n";
+    if ("calculator_display_name" in object) {
+      output += "\n";
+      output += indent + "calculator_display_name:";
+      output += ' "' + object["calculator_display_name"] + '"\n';
     }
     if ("row_group_count" in object) {
         output += "\n"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   # A webserver to host the files
   web:

--- a/pylib/calculator_producer.py
+++ b/pylib/calculator_producer.py
@@ -126,6 +126,11 @@ def calculator_function(input_files: CalculatorInputFiles, groups: Dict[str, str
         item_styles=item_styles,
         # The name of the calculator
         calculator_name=calculator_name,
+        # The name of the calculator for display
+        calculator_display_name=resource_list.calculator_display_name,
+        # The version of the game the calculator has been updated for
+        game_version=resource_list.game_version,
+        # The image of all stitched item images
         resource_image=calculator_item_image,
         # Javascript formatting functions for recipe instructions # TODO this should be made into format strings to save space
         recipe_type_format_js=recipe_type_format_js,

--- a/pylib/resource_list.py
+++ b/pylib/resource_list.py
@@ -210,7 +210,7 @@ def optional_quote_wrapping(string: str) -> str:
 class ResourceList():
     def __init__(self) -> None:
         self.authors: OrderedDict[str, str] = OrderedDict()
-        self.index_page_display_name: str = ""
+        self.calculator_display_name: str = ""
         self.game_version: str = ""
         self.row_group_count: int = 1
         self.note: str = ""
@@ -221,7 +221,7 @@ class ResourceList():
         self.default_stack_size: str = ""
         self.resources: List[Union[Resource, Heading]] = []
 
-        self.valid_keys = ['authors', 'index_page_display_name', 'game_version', 'row_group_count', 'note', 'banner_message', 'recipe_types', 'requirement_groups', 'stack_sizes', 'default_stack_size', 'resources']
+        self.valid_keys = ['authors', 'calculator_display_name', 'game_version', 'row_group_count', 'note', 'banner_message', 'recipe_types', 'requirement_groups', 'stack_sizes', 'default_stack_size', 'resources']
 
     def parse(self, tuple_tree: Any) -> List[TokenError]:
         errors: List[TokenError] = []
@@ -251,13 +251,13 @@ class ResourceList():
 
                 self.authors[str(key.value)] = str(value.value)
 
-        # Load index_page_display_name into a typed object
-        if 'index_page_display_name' in tokenless_keys:
-            index_page_display_name = tokenless_keys["index_page_display_name"]
-            if type(index_page_display_name.value) != str:
-                errors.append(TokenError("index_page_display_name should be a string not a {}".format(str(type(index_page_display_name.value))), Token().from_yaml_scalar_node(index_page_display_name.token)))
+        # Load calculator_display_name into a typed object
+        if 'calculator_display_name' in tokenless_keys:
+            calculator_display_name = tokenless_keys["calculator_display_name"]
+            if type(calculator_display_name.value) != str:
+                errors.append(TokenError("calculator_display_name should be a string not a {}".format(str(type(calculator_display_name.value))), Token().from_yaml_scalar_node(calculator_display_name.token)))
 
-            self.index_page_display_name = str(index_page_display_name.value)
+            self.calculator_display_name = str(calculator_display_name.value)
 
         # Load game_version into a typed object
         if 'game_version' in tokenless_keys:
@@ -365,7 +365,7 @@ class ResourceList():
     def to_primitive(self) -> Any:
         return {
             "authors": get_primitive(self.authors),
-            "index_page_display_name": get_primitive(self.index_page_display_name),
+            "calculator_display_name": get_primitive(self.calculator_display_name),
             "game_version": get_primitive(self.game_version),
             "row_group_count": get_primitive(self.row_group_count),
             "note": get_primitive(self.note),
@@ -383,9 +383,9 @@ class ResourceList():
             output.append(indent + "authors:")
             for authors_k, authors_v in self.authors.items():
                 output.append(indent + "  " + authors_k + ": " + yaml_string(authors_v, indent + "  "))
-        if self.index_page_display_name != "":
+        if self.calculator_display_name != "":
             output.append("")
-            output.append(indent + "index_page_display_name: " + yaml_string(self.index_page_display_name, indent))
+            output.append(indent + "calculator_display_name: " + yaml_string(self.calculator_display_name, indent))
         if self.game_version != "":
             output.append("")
             output.append(indent + "game_version: " + yaml_string(self.game_version, indent))

--- a/pylib/yaml_linter_producer.py
+++ b/pylib/yaml_linter_producer.py
@@ -73,7 +73,7 @@ def resource_list_parser_function(input_files: SingleFile, groups: Dict[str, str
     os.makedirs(os.path.dirname(page_metadata_path), exist_ok=True)
     with open(page_metadata_path, 'w') as f:
         json.dump({
-            "calculator_name": resource_list.index_page_display_name
+            "calculator_name": resource_list.calculator_display_name
         }, f)
 
     return [

--- a/resource_lists/astroneer/resources.yaml
+++ b/resource_lists/astroneer/resources.yaml
@@ -4,7 +4,7 @@ authors:
   Kevin: ""
   Alban: "https://github.com/mopolita"
 
-index_page_display_name: Astroneer
+calculator_display_name: Astroneer
 
 recipe_types:
   Backpack Printer: Use a Backpack Printer to turn {IN_ITEMS} into {OUT_ITEM}

--- a/resource_lists/breath of the wild/resources.yaml
+++ b/resource_lists/breath of the wild/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Asher: "https://aglick.com"
 
-index_page_display_name: Breath of<br>the Wild
+calculator_display_name: Breath of<br>the Wild
 
 row_group_count: 5
 

--- a/resource_lists/enshrouded/resources.yaml
+++ b/resource_lists/enshrouded/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Bloodtap: ""
 
-index_page_display_name: Enshrouded
+calculator_display_name: Enshrouded
 
 note: |
   Extra thanks to:

--- a/resource_lists/global_city/resources.yaml
+++ b/resource_lists/global_city/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   MochSA: "https://github.com/mochsa/"
 
-index_page_display_name: Global City
+calculator_display_name: Global City
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/resource_lists/haven/resources.yaml
+++ b/resource_lists/haven/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Ben: "https://benjaminvreeland.com"
 
-index_page_display_name: Haven
+calculator_display_name: Haven
 
 game_version: "1.1.302"
 

--- a/resource_lists/how_to_survive/resources.yaml
+++ b/resource_lists/how_to_survive/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Ben: "https://benjaminvreeland.com"
 
-index_page_display_name: How to Survive
+calculator_display_name: How to Survive
 
 game_version: "Oct 21 2014, 18:23:47"
 

--- a/resource_lists/minecraft/resources.yaml
+++ b/resource_lists/minecraft/resources.yaml
@@ -4,7 +4,7 @@ authors:
   Kevin: kroden3d@gmail.com
   Marc: "https://github.com/mmodrow"
 
-index_page_display_name: Minecraft
+calculator_display_name: Minecraft
 
 game_version: Java 1.21
 

--- a/resource_lists/moonlighter/resources.yaml
+++ b/resource_lists/moonlighter/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Asher: "https://aglick.com"
 
-index_page_display_name: Moonlighter
+calculator_display_name: Moonlighter
 
 recipe_types:
   Smith: Buy {OUT_ITEM} for {IN_ITEMS} from Vulcan's Forge

--- a/resource_lists/nier automata/resources.yaml
+++ b/resource_lists/nier automata/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Asher: "https://aglick.com"
 
-index_page_display_name: Nier Automata
+calculator_display_name: Nier Automata
 
 row_group_count: 4
 

--- a/resource_lists/outworld_station/resources.yaml
+++ b/resource_lists/outworld_station/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Schop: "https://github.com/Schop0"
 
-index_page_display_name: Outworld Station
+calculator_display_name: Outworld Station
 
 game_version: "0.1.2.0 (Early Access)"
 

--- a/resource_lists/skyrim/resources.yaml
+++ b/resource_lists/skyrim/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Asher: ""
 
-index_page_display_name: Skyrim
+calculator_display_name: Skyrim
 
 recipe_types:
   Craft: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/resource_lists/skyrim/resources.yaml
+++ b/resource_lists/skyrim/resources.yaml
@@ -1,6 +1,6 @@
 ---
 authors:
-  Asher: ""
+  Asher: "https://aglick.com"
 
 calculator_display_name: Skyrim
 

--- a/resource_lists/skyward_sword/resources.yaml
+++ b/resource_lists/skyward_sword/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Asher: "https://aglick.com"
 
-index_page_display_name: Skyward Sword
+calculator_display_name: Skyward Sword
 
 recipe_types:
   Beedle: Buy {OUT_ITEM} for {IN_ITEMS} from Beedle

--- a/resource_lists/stardew valley/resources.yaml
+++ b/resource_lists/stardew valley/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Ben: "https://benjaminvreeland.com"
 
-index_page_display_name: Stardew Valley
+calculator_display_name: Stardew Valley
 
 game_version: "1.6.15"
 

--- a/resource_lists/subnautica below zero/resources.yaml
+++ b/resource_lists/subnautica below zero/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Ben: "https://benjaminvreeland.com"
 
-index_page_display_name: "Subnautica: Below Zero"
+calculator_display_name: "Subnautica: Below Zero"
 
 game_version: What the Dock Update
 

--- a/resource_lists/subnautica/resources.yaml
+++ b/resource_lists/subnautica/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Ben: "https://benjaminvreeland.com"
 
-index_page_display_name: Subnautica
+calculator_display_name: Subnautica
 
 game_version: Living Large Update
 

--- a/resource_lists/subnautica_2/resources.yaml
+++ b/resource_lists/subnautica_2/resources.yaml
@@ -3,7 +3,7 @@ authors:
   puhi8: "https://puhi8.github.io/me/"
 
 
-index_page_display_name: Subnautica 2
+calculator_display_name: Subnautica 2
 
 game_version: Early Access Hotfix 2
 

--- a/resource_lists/super motherload/resources.yaml
+++ b/resource_lists/super motherload/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Ben: "https://benjaminvreeland.com"
 
-index_page_display_name: Super Motherload
+calculator_display_name: Super Motherload
 
 game_version: "1.04.01"
 

--- a/resource_lists/terratech/resources.yaml
+++ b/resource_lists/terratech/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   jojoblackFr: "https://github.com/jojoblackFr"
 
-index_page_display_name: TerraTech
+calculator_display_name: TerraTech
 
 game_version: T1715700934 ba426e1f
 

--- a/resource_lists/the forest/resources.yaml
+++ b/resource_lists/the forest/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Ben: "https://benjaminvreeland.com"
 
-index_page_display_name: The Forest
+calculator_display_name: The Forest
 
 game_version: V1.12 - VR
 

--- a/resource_lists/the survivalists/resources.yaml
+++ b/resource_lists/the survivalists/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   jojoblackFr: "https://github.com/jojoblackFr"
 
-index_page_display_name: The Survivalists
+calculator_display_name: The Survivalists
 
 game_version: "1.1.13.565.740066"
 

--- a/resource_lists/void_bastards/resources.yaml
+++ b/resource_lists/void_bastards/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Ben: "https://benjaminvreeland.com"
 
-index_page_display_name: Void Bastards
+calculator_display_name: Void Bastards
 
 game_version: "9388"
 

--- a/resource_lists/witcher wild hunt/resources.yaml
+++ b/resource_lists/witcher wild hunt/resources.yaml
@@ -2,7 +2,7 @@
 authors:
   Asher: "https://aglick.com"
 
-index_page_display_name: Witcher 3
+calculator_display_name: Witcher 3
 
 recipe_types:
   Alchemy: Craft {OUT_ITEM} with {IN_ITEMS}

--- a/scripts/resource_list_type_generator.py
+++ b/scripts/resource_list_type_generator.py
@@ -22,7 +22,7 @@ def main() -> None:
                     default="OrderedDict()",
                 ),
                 Variable(
-                    name="index_page_display_name",
+                    name="calculator_display_name",
                     type="str",
                     default='""',
                     blank_lines_above_field=1,
@@ -221,7 +221,7 @@ def main() -> None:
                     default="{}"
                 ),
                 Variable(
-                    name="index_page_display_name",
+                    name="calculator_display_name",
                     type="str",
                     default='""',
                     line_above=True,  # Formatting Style

--- a/tests/good_fields.yaml
+++ b/tests/good_fields.yaml
@@ -3,7 +3,7 @@ authors:
   TesterPerson: testerperson@example.com
   BOT: bot.example.com
 
-index_page_display_name: Test
+calculator_display_name: Test
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/tests/invalid_raw_resource.yaml
+++ b/tests/invalid_raw_resource.yaml
@@ -3,7 +3,7 @@ authors:
   TesterPerson: testerperson@example.com
   BOT: bot.example.com
 
-index_page_display_name: Test
+calculator_display_name: Test
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/tests/invalid_recipe_type.yaml
+++ b/tests/invalid_recipe_type.yaml
@@ -3,7 +3,7 @@ authors:
   TesterPerson: testerperson@example.com
   BOT: bot.example.com
 
-index_page_display_name: Test
+calculator_display_name: Test
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/tests/invalid_requirement_count.yaml
+++ b/tests/invalid_requirement_count.yaml
@@ -3,7 +3,7 @@ authors:
   TesterPerson: testerperson@example.com
   BOT: bot.example.com
 
-index_page_display_name: Test
+calculator_display_name: Test
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/tests/invalid_requirement_name.yaml
+++ b/tests/invalid_requirement_name.yaml
@@ -3,7 +3,7 @@ authors:
   TesterPerson: testerperson@example.com
   BOT: bot.example.com
 
-index_page_display_name: Test
+calculator_display_name: Test
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/tests/invalid_resource_list_key.yaml
+++ b/tests/invalid_resource_list_key.yaml
@@ -3,7 +3,7 @@ authors:
   TesterPerson: testerperson@example.com
   BOT: bot.example.com
 
-index_page_display_name: Test
+calculator_display_name: Test
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/tests/non_string_authors.yaml
+++ b/tests/non_string_authors.yaml
@@ -2,7 +2,7 @@
 authors:
   -5: 123456
 
-index_page_display_name: Test
+calculator_display_name: Test
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/tests/non_string_index_display_name.yaml
+++ b/tests/non_string_index_display_name.yaml
@@ -3,7 +3,7 @@ authors:
   TesterPerson: testerperson@example.com
   BOT: bot.example.com
 
-index_page_display_name: -1
+calculator_display_name: -1
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/tests/non_string_recipe_types.yaml
+++ b/tests/non_string_recipe_types.yaml
@@ -3,7 +3,7 @@ authors:
   TesterPerson: testerperson@example.com
   BOT: bot.example.com
 
-index_page_display_name: Test
+calculator_display_name: Test
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}

--- a/tests/unused_recipe_type.yaml
+++ b/tests/unused_recipe_type.yaml
@@ -3,7 +3,7 @@ authors:
   TesterPerson: testerperson@example.com
   BOT: bot.example.com
 
-index_page_display_name: Test
+calculator_display_name: Test
 
 recipe_types:
   Crafting: Craft {IN_ITEMS} into {OUT_ITEM}


### PR DESCRIPTION
- Renamed `index_page_display_name` to `calculator_display_name` to reflect that is not merely used on the index page anymore, ideally the YAML shouldn't know that kind of display concern anyway. This caused the diff to touch all calc files so the actual changes are much smaller.
- Removed `version` from `docker-compose.yaml` due to the warning: "the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
- Some small readme improvements linking to mentioned tools.
- The main event: added the calculator name to the page title and heading, and created an info box opened by tapping the info icon to the right. This displays (in the same style as existing popovers) the version of the game, all listed authors, and links to those authors' sites (handling `mailto` if they listed an email).
  - Handles blank links by not making a link.
  - Handles only version or only authors populated.
  - Hides info icon entirely if neither populated.

<img width="896" height="231" alt="image" src="https://github.com/user-attachments/assets/86d33d5f-6c74-4521-8631-25cfe1e047e2" />
<img width="563" height="299" alt="image" src="https://github.com/user-attachments/assets/bd93a6a5-c1e8-4c5a-ac7d-fe716661c8f9" />
<img width="521" height="179" alt="image" src="https://github.com/user-attachments/assets/ebf92c2d-8056-4045-ba88-64d9d657517c" />
<img width="538" height="210" alt="image" src="https://github.com/user-attachments/assets/feb57547-d36e-41ef-8604-a8ef99983516" />
<img width="516" height="107" alt="image" src="https://github.com/user-attachments/assets/bb940618-4988-4cda-9e6f-a3ef100f69ee" />


